### PR TITLE
feat: IndexInfo 엔티티 및 Repository 구현

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/entity/IndexInfo.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/entity/IndexInfo.java
@@ -1,0 +1,60 @@
+package com.sprint.mission.findex.domain.indexinfo.entity;
+
+import com.sprint.mission.findex.global.common.entity.BaseUpdatableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "index_info", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"index_classification", "index_name"})
+})
+public class IndexInfo extends BaseUpdatableEntity {
+
+  @Column(name = "index_classification", nullable = false, length = 240)
+  private String indexClassification;
+
+  @Column(name = "index_name", nullable = false, length = 240)
+  private String indexName;
+
+  @Column(name = "employed_items_count", nullable = false)
+  private Integer employedItemsCount;
+
+  @Column(name = "base_point_in_time", nullable = false, length = 50)
+  private String basePointInTime;
+
+  @Column(name = "base_index", nullable = false, precision = 20, scale = 4)
+  private BigDecimal baseIndex;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "source_type", nullable = false, length = 10)
+  private SourceType sourceType;
+
+  public enum SourceType {
+    USER,
+    OPEN_API
+  }
+
+  @Column(name = "favorite", nullable = false)
+  private Boolean favorite = false;
+
+  public IndexInfo(String indexClassification, String indexName, Integer employedItemsCount,
+      String basePointInTime, BigDecimal baseIndex, SourceType sourceType, Boolean favorite) {
+    this.indexClassification = indexClassification;
+    this.indexName = indexName;
+    this.employedItemsCount = employedItemsCount;
+    this.basePointInTime = basePointInTime;
+    this.baseIndex = baseIndex;
+    this.sourceType = sourceType;
+    this.favorite = favorite;
+  }
+}

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/IndexInfoRepository.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/IndexInfoRepository.java
@@ -1,0 +1,9 @@
+package com.sprint.mission.findex.domain.indexinfo.repository;
+
+import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IndexInfoRepository extends JpaRepository<IndexInfo, UUID> {
+
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #3 

## PR 유형

- [x] feat: 새로운 기능

## 작업 내용

- `IndexInfo` 엔티티 추가 (BaseUpdatableEntity 상속, index_classification + index_name 유니크 제약)
- `SourceType` Enum 추가 (`USER`, `OPEN_API`)
- `IndexInfoRepository` 추가

## 테스트 내용

- [x] 로컬 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- AutoSyncConfig 자동 생성 방식은 ADR Issue 결론에 따라 M1-2에서 반영 예정