### PR TITLE
feat: IndexData 엔티티 + Repository 구현

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/entity/IndexData.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/entity/IndexData.java
@@ -1,0 +1,106 @@
+package com.sprint.mission.findex.domain.indexdata.entity;
+
+import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
+import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo.SourceType;
+import com.sprint.mission.findex.global.common.entity.BaseUpdatableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "index_data",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"index_info_id", "base_date"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IndexData extends BaseUpdatableEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "index_info_id", nullable = false)
+  private IndexInfo indexInfo;
+
+  @Column(name = "base_date", nullable = false)
+  private LocalDate baseDate;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "source_type", nullable = false, length = 10, columnDefinition = "VARCHAR(10)")
+  private SourceType sourceType;
+
+  @Column(name = "market_price", nullable = false, precision = 20, scale = 4)
+  private BigDecimal marketPrice;
+
+  @Column(name = "closing_price", nullable = false, precision = 20, scale = 4)
+  private BigDecimal closingPrice;
+
+  @Column(name = "high_price", nullable = false, precision = 20, scale = 4)
+  private BigDecimal highPrice;
+
+  @Column(name = "low_price", nullable = false, precision = 20, scale = 4)
+  private BigDecimal lowPrice;
+
+  @Column(name = "versus", nullable = false, precision = 20, scale = 4)
+  private BigDecimal versus;
+
+  @Column(name = "fluctuation_rate", nullable = false, precision = 10, scale = 4)
+  private BigDecimal fluctuationRate;
+
+  @Column(name = "trading_quantity", nullable = false)
+  private Long tradingQuantity;
+
+  @Column(name = "trading_price", nullable = false, precision = 30, scale = 4)
+  private BigDecimal tradingPrice;
+
+  @Column(name = "market_total_amount", nullable = false, precision = 30, scale = 4)
+  private BigDecimal marketTotalAmount;
+
+  @Builder
+  public IndexData(IndexInfo indexInfo, LocalDate baseDate, SourceType sourceType,
+      BigDecimal marketPrice, BigDecimal closingPrice,
+      BigDecimal highPrice, BigDecimal lowPrice,
+      BigDecimal versus, BigDecimal fluctuationRate,
+      Long tradingQuantity, BigDecimal tradingPrice,
+      BigDecimal marketTotalAmount) {
+    this.indexInfo = indexInfo;
+    this.baseDate = baseDate;
+    this.sourceType = sourceType;
+    this.marketPrice = marketPrice;
+    this.closingPrice = closingPrice;
+    this.highPrice = highPrice;
+    this.lowPrice = lowPrice;
+    this.versus = versus;
+    this.fluctuationRate = fluctuationRate;
+    this.tradingQuantity = tradingQuantity;
+    this.tradingPrice = tradingPrice;
+    this.marketTotalAmount = marketTotalAmount;
+  }
+
+  public void update(BigDecimal marketPrice, BigDecimal closingPrice,
+      BigDecimal highPrice, BigDecimal lowPrice,
+      BigDecimal versus, BigDecimal fluctuationRate,
+      Long tradingQuantity, BigDecimal tradingPrice,
+      BigDecimal marketTotalAmount, SourceType sourceType) {
+    this.marketPrice = marketPrice;
+    this.closingPrice = closingPrice;
+    this.highPrice = highPrice;
+    this.lowPrice = lowPrice;
+    this.versus = versus;
+    this.fluctuationRate = fluctuationRate;
+    this.tradingQuantity = tradingQuantity;
+    this.tradingPrice = tradingPrice;
+    this.marketTotalAmount = marketTotalAmount;
+    this.sourceType = sourceType;
+  }
+}

--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/repository/IndexDataRepository.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/repository/IndexDataRepository.java
@@ -1,0 +1,20 @@
+package com.sprint.mission.findex.domain.indexdata.repository;
+
+import com.sprint.mission.findex.domain.indexdata.entity.IndexData;
+import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IndexDataRepository extends JpaRepository<IndexData, UUID> {
+
+  boolean existsByIndexInfoAndBaseDate(IndexInfo indexInfo, LocalDate baseDate);
+
+  Optional<IndexData> findByIndexInfoAndBaseDate(IndexInfo indexInfo, LocalDate baseDate);
+
+  List<IndexData> findByIndexInfoIdAndBaseDateBetween(UUID indexInfoId, LocalDate from, LocalDate to);
+
+  List<IndexData> findByBaseDateBetween(LocalDate from, LocalDate to);
+}


### PR DESCRIPTION
- IndexData 엔티티 추가
	- BaseUpdatableEntity 상속(id UUID 자동 생성, createdAt, updatedAt 포함)
	- IndexInfo와 ManytoOne 연관관계 설정(FetchType.Lazy)
	- (index_info_id, base_date) 유니크 제약 적용
	- 가격/금액 필드 BigDecimal 사용(ERD 기준 precision/scale 적용)
	- source_type VARCHAR(10) columnDefinition 명시
- IndexDataRepository 추가
	- existsByIndexInfoAndBaseDate: 중복 체크용
	- findByIndexInfoAndBaseDate: 단건 조회용
	- findByIndexInfoIdAndBaseDateBetween: 차트용 날짜 범위 조회
	- findByBaseDateBetween: 랭킹용 전체 지수 날짜 범위 조회

## 관련 이슈

- Closes #10 
- Closes #8 

## PR 유형

- [x] feat: 새로운 기능
- [ ] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가·수정
- [ ] deploy: 배포 관련
- [ ] chore: 빌드·설정 변경

## 작업 내용

- IndexData 엔티티 및 Repository를 구현했습니다.
- M2-2(CRUD), M2-3(목록조회), M2-4(CSV Export), M6(대시보드)의 전제 조건이 되는 PR입니다.
-

## 테스트 내용

- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 해당 없음

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [ ] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트
- ERD 기준으로 작성했습니다.
- 해당 작업과 관련하여 Issue 오픈했습니다. 
- `ddl-auto: update` + `schema-h2.sql` 조합으로 로컬 테스트를 진행했습니다.

## 스크린샷 / 참고 자료

- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 지수 데이터 저장 및 조회 기능이 추가되었습니다.
* 특정 지수와 날짜별로 시장가, 종가, 고가, 저가, 변동률, 거래량 등의 정보를 관리할 수 있습니다.
* 날짜 범위별, 특정 지수별 데이터 조회 및 중복 데이터 방지를 위한 검증 기능이 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->