### PR TITLE
feat: AutoSyncConfig 엔티티 및 Repository 구현

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/autosync/entity/AutoSyncConfig.java
+++ b/src/main/java/com/sprint/mission/findex/domain/autosync/entity/AutoSyncConfig.java
@@ -1,0 +1,36 @@
+package com.sprint.mission.findex.domain.autosync.entity;
+
+import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
+import com.sprint.mission.findex.global.common.entity.BaseUpdatableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "auto_sync_config")
+public class AutoSyncConfig extends BaseUpdatableEntity {
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "index_info_id", nullable = false, unique = true)
+  private IndexInfo indexInfo;
+
+  @Column(name = "enabled", nullable = false)
+  private Boolean enabled = false;
+
+  public AutoSyncConfig(IndexInfo indexInfo) {
+    this.indexInfo = indexInfo;
+    this.enabled = false;
+  }
+
+  public void updateEnabled(Boolean enabled) {
+    this.enabled = enabled;
+  }
+}

--- a/src/main/java/com/sprint/mission/findex/domain/autosync/entity/AutoSyncConfig.java
+++ b/src/main/java/com/sprint/mission/findex/domain/autosync/entity/AutoSyncConfig.java
@@ -23,14 +23,14 @@ public class AutoSyncConfig extends BaseUpdatableEntity {
   private IndexInfo indexInfo;
 
   @Column(name = "enabled", nullable = false)
-  private Boolean enabled = false;
+  private boolean enabled = false;
 
   public AutoSyncConfig(IndexInfo indexInfo) {
     this.indexInfo = indexInfo;
     this.enabled = false;
   }
 
-  public void updateEnabled(Boolean enabled) {
+  public void updateEnabled(boolean enabled) {
     this.enabled = enabled;
   }
 }

--- a/src/main/java/com/sprint/mission/findex/domain/autosync/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/com/sprint/mission/findex/domain/autosync/repository/AutoSyncConfigRepository.java
@@ -1,0 +1,20 @@
+package com.sprint.mission.findex.domain.autosync.repository;
+
+import com.sprint.mission.findex.domain.autosync.entity.AutoSyncConfig;
+import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, UUID> {
+
+  // M1(IndexInfoService)에서 IndexInfo 등록 시 중복 생성 방지용
+  boolean existsByIndexInfo(IndexInfo indexInfo);
+
+  // 설정 조회 (단건) - PATCH API, 배치에서 활용
+  Optional<AutoSyncConfig> findByIndexInfo(IndexInfo indexInfo);
+
+  // 배치(Spring Scheduler)에서 활성화된 지수 목록 전체 조회
+  List<AutoSyncConfig> findAllByEnabledTrue();
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #9

## PR 유형

- [x] feat: 새로운 기능
## 작업 내용
- `AutoSyncConfig` 엔티티 추가 (IndexInfo 1:1 단방향 참조, `enabled` 기본값 false)
- `AutoSyncConfigRepository` 추가
- `existsByIndexInfo` — M1 서비스에서 IndexInfo 등록 시 중복 생성 방지
- `findByIndexInfo` — 설정 단건 조회 (PATCH API 및 배치 활용)
- `findAllByEnabledTrue` — Spring Scheduler 배치에서 활성화된 지수 목록 조회

## 테스트 내용

- [x] 로컬 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- `@ManyToOne` 대신 `@OneToOne`을 사용한 것이 적절한지 확인 부탁드립니다. (`indexInfoId`에 UNIQUE 제약이 있어 의미상 1:1로 표현했습니다.)

## 스크린샷 / 참고 자료

- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인덱스별 자동 동기화 설정 기능이 추가되었습니다. 사용자는 특정 인덱스에 대해 자동 동기화를 활성화/비활성화할 수 있습니다.
  * 활성화된 설정은 배치/스케줄 처리 시 자동으로 탐지되어 적용됩니다.
  * 설정의 중복 등록 방지와 단건 조회, 활성 설정 일괄 조회를 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->