### PR TITLE
feat: 금융위원회 지수시세 Open API 클라이언트 구현

### DIFF
--- a/src/main/java/com/sprint/mission/findex/FindexApplication.java
+++ b/src/main/java/com/sprint/mission/findex/FindexApplication.java
@@ -1,5 +1,6 @@
 package com.sprint.mission.findex;
 
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -9,7 +10,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 public class FindexApplication {
 
 	public static void main(String[] args) {
+
 		SpringApplication.run(FindexApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/client/KrxOpenApiClient.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/client/KrxOpenApiClient.java
@@ -1,0 +1,9 @@
+package com.sprint.mission.findex.domain.syncclient.client;
+
+import com.sprint.mission.findex.domain.syncclient.dto.IndexDataApiResponse;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface KrxOpenApiClient {
+    List<IndexDataApiResponse> fetchByDateRange(String indexName, LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/client/KrxOpenApiClientImpl.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/client/KrxOpenApiClientImpl.java
@@ -7,11 +7,14 @@ import com.sprint.mission.findex.global.exception.ApiException;
 import com.sprint.mission.findex.global.exception.ApiException.ERROR;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -28,9 +31,13 @@ public class KrxOpenApiClientImpl implements KrxOpenApiClient {
     public KrxOpenApiClientImpl(
             @Value("${public-data.base-url}") String baseUrl,
             @Value("${public-data.api-key}") String apiKey,
+            RestTemplateBuilder restTemplateBuilder,
             ObjectMapper objectMapper
     ) {
-        this.restTemplate = new RestTemplate();
+        this.restTemplate = restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(3))
+                .setReadTimeout(Duration.ofSeconds(5))
+                .build();
         this.baseUrl = baseUrl;
         this.apiKey = apiKey;
         this.objectMapper = objectMapper;
@@ -38,38 +45,65 @@ public class KrxOpenApiClientImpl implements KrxOpenApiClient {
 
     @Override
     public List<IndexDataApiResponse> fetchByDateRange(String indexName, LocalDate from, LocalDate to) {
+        if (indexName == null || indexName.isBlank()) {
+            throw new IllegalArgumentException("indexName must not be blank");
+        }
+        if (from == null || to == null) {
+            throw new IllegalArgumentException("from and to must not be null");
+        }
+        if (from.isAfter(to)) {
+            throw new IllegalArgumentException("from must be before or equal to to");
+        }
+
         try {
             String encodedIndexName = UriUtils.encode(indexName, StandardCharsets.UTF_8);
+            int pageNo = 1;
+            int numOfRows = 1000;
+            List<IndexDataApiResponse> allItems = new ArrayList<>();
 
-            String url = baseUrl + "/getStockMarketIndex"
-                    + "?serviceKey=" + apiKey
-                    + "&resultType=json"
-                    + "&pageNo=1"
-                    + "&numOfRows=1000"
-                    + "&beginBasDt=" + from.format(DateTimeFormatter.BASIC_ISO_DATE)
-                    + "&endBasDt=" + to.format(DateTimeFormatter.BASIC_ISO_DATE)
-                    + "&idxNm=" + encodedIndexName;
+            while (true) {
+                String url = baseUrl + "/getStockMarketIndex"
+                        + "?serviceKey=" + apiKey
+                        + "&resultType=json"
+                        + "&pageNo=" + pageNo
+                        + "&numOfRows=" + numOfRows
+                        + "&beginBasDt=" + from.format(DateTimeFormatter.BASIC_ISO_DATE)
+                        + "&endBasDt=" + to.format(DateTimeFormatter.BASIC_ISO_DATE)
+                        + "&idxNm=" + encodedIndexName;
 
+                URI uri = URI.create(url);
+                String responseBody = restTemplate.getForObject(uri, String.class);
 
-            URI uri = URI.create(url);
-            String responseBody = restTemplate.getForObject(uri, String.class);
+                if (responseBody == null || responseBody.isBlank()) {
+                    break;
+                }
 
+                KrxApiResponseWrapper wrapper =
+                        objectMapper.readValue(responseBody, KrxApiResponseWrapper.class);
 
-            if (responseBody == null || responseBody.isBlank()) {
-                return Collections.emptyList();
+                if (wrapper.getResponse() == null
+                        || wrapper.getResponse().getBody() == null
+                        || wrapper.getResponse().getBody().getItems() == null) {
+                    break;
+                }
+
+                List<IndexDataApiResponse> pageItems =
+                        wrapper.getResponse().getBody().getItems().getItem();
+
+                if (pageItems == null || pageItems.isEmpty()) {
+                    break;
+                }
+
+                allItems.addAll(pageItems);
+
+                if (pageItems.size() < numOfRows) {
+                    break;
+                }
+
+                pageNo++;
             }
 
-            KrxApiResponseWrapper wrapper =
-                    objectMapper.readValue(responseBody, KrxApiResponseWrapper.class);
-
-            if (wrapper.getResponse() == null
-                    || wrapper.getResponse().getBody() == null
-                    || wrapper.getResponse().getBody().getItems() == null
-                    || wrapper.getResponse().getBody().getItems().getItem() == null) {
-                return Collections.emptyList();
-            }
-
-            return wrapper.getResponse().getBody().getItems().getItem();
+            return allItems.isEmpty() ? Collections.emptyList() : allItems;
 
         } catch (RestClientException e) {
             throw new ApiException(ERROR.SYNC_JOB_OPEN_API_ERROR);

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/client/KrxOpenApiClientImpl.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/client/KrxOpenApiClientImpl.java
@@ -35,8 +35,8 @@ public class KrxOpenApiClientImpl implements KrxOpenApiClient {
             ObjectMapper objectMapper
     ) {
         this.restTemplate = restTemplateBuilder
-                .setConnectTimeout(Duration.ofSeconds(3))
-                .setReadTimeout(Duration.ofSeconds(5))
+                .connectTimeout(Duration.ofSeconds(3))
+                .readTimeout(Duration.ofSeconds(5))
                 .build();
         this.baseUrl = baseUrl;
         this.apiKey = apiKey;
@@ -46,13 +46,13 @@ public class KrxOpenApiClientImpl implements KrxOpenApiClient {
     @Override
     public List<IndexDataApiResponse> fetchByDateRange(String indexName, LocalDate from, LocalDate to) {
         if (indexName == null || indexName.isBlank()) {
-            throw new IllegalArgumentException("indexName must not be blank");
+            throw new ApiException(ERROR.COMMON_INVALID_REQUEST);
         }
         if (from == null || to == null) {
-            throw new IllegalArgumentException("from and to must not be null");
+            throw new ApiException(ERROR.COMMON_INVALID_REQUEST);
         }
         if (from.isAfter(to)) {
-            throw new IllegalArgumentException("from must be before or equal to to");
+            throw new ApiException(ERROR.COMMON_INVALID_REQUEST);
         }
 
         try {
@@ -81,14 +81,14 @@ public class KrxOpenApiClientImpl implements KrxOpenApiClient {
                 KrxApiResponseWrapper wrapper =
                         objectMapper.readValue(responseBody, KrxApiResponseWrapper.class);
 
-                if (wrapper.getResponse() == null
-                        || wrapper.getResponse().getBody() == null
-                        || wrapper.getResponse().getBody().getItems() == null) {
+                if (wrapper.response() == null
+                        || wrapper.response().body() == null
+                        || wrapper.response().body().items() == null) {
                     break;
                 }
 
                 List<IndexDataApiResponse> pageItems =
-                        wrapper.getResponse().getBody().getItems().getItem();
+                        wrapper.response().body().items().item();
 
                 if (pageItems == null || pageItems.isEmpty()) {
                     break;
@@ -105,6 +105,8 @@ public class KrxOpenApiClientImpl implements KrxOpenApiClient {
 
             return allItems.isEmpty() ? Collections.emptyList() : allItems;
 
+        } catch (ApiException e) {
+            throw e;
         } catch (RestClientException e) {
             throw new ApiException(ERROR.SYNC_JOB_OPEN_API_ERROR);
         } catch (Exception e) {

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/client/KrxOpenApiClientImpl.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/client/KrxOpenApiClientImpl.java
@@ -1,0 +1,80 @@
+package com.sprint.mission.findex.domain.syncclient.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.mission.findex.domain.syncclient.dto.IndexDataApiResponse;
+import com.sprint.mission.findex.domain.syncclient.dto.KrxApiResponseWrapper;
+import com.sprint.mission.findex.global.exception.ApiException;
+import com.sprint.mission.findex.global.exception.ApiException.ERROR;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriUtils;
+
+@Component
+public class KrxOpenApiClientImpl implements KrxOpenApiClient {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final String baseUrl;
+    private final String apiKey;
+
+    public KrxOpenApiClientImpl(
+            @Value("${public-data.base-url}") String baseUrl,
+            @Value("${public-data.api-key}") String apiKey,
+            ObjectMapper objectMapper
+    ) {
+        this.restTemplate = new RestTemplate();
+        this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<IndexDataApiResponse> fetchByDateRange(String indexName, LocalDate from, LocalDate to) {
+        try {
+            String encodedIndexName = UriUtils.encode(indexName, StandardCharsets.UTF_8);
+
+            String url = baseUrl + "/getStockMarketIndex"
+                    + "?serviceKey=" + apiKey
+                    + "&resultType=json"
+                    + "&pageNo=1"
+                    + "&numOfRows=1000"
+                    + "&beginBasDt=" + from.format(DateTimeFormatter.BASIC_ISO_DATE)
+                    + "&endBasDt=" + to.format(DateTimeFormatter.BASIC_ISO_DATE)
+                    + "&idxNm=" + encodedIndexName;
+
+
+            URI uri = URI.create(url);
+            String responseBody = restTemplate.getForObject(uri, String.class);
+
+
+            if (responseBody == null || responseBody.isBlank()) {
+                return Collections.emptyList();
+            }
+
+            KrxApiResponseWrapper wrapper =
+                    objectMapper.readValue(responseBody, KrxApiResponseWrapper.class);
+
+            if (wrapper.getResponse() == null
+                    || wrapper.getResponse().getBody() == null
+                    || wrapper.getResponse().getBody().getItems() == null
+                    || wrapper.getResponse().getBody().getItems().getItem() == null) {
+                return Collections.emptyList();
+            }
+
+            return wrapper.getResponse().getBody().getItems().getItem();
+
+        } catch (RestClientException e) {
+            throw new ApiException(ERROR.SYNC_JOB_OPEN_API_ERROR);
+        } catch (Exception e) {
+            throw new ApiException(ERROR.SYNC_JOB_OPEN_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/IndexDataApiResponse.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/IndexDataApiResponse.java
@@ -1,31 +1,22 @@
 package com.sprint.mission.findex.domain.syncclient.dto;
 
 import java.math.BigDecimal;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
 
-@Getter
-@NoArgsConstructor
-@ToString
-public class IndexDataApiResponse {
-
-    private String basDt;
-    private String idxNm;
-    private String idxCsf;
-    private Integer epyItmsCnt;
-
-    private BigDecimal clpr;
-    private BigDecimal vs;
-    private BigDecimal fltRt;
-    private BigDecimal mkp;
-    private BigDecimal hipr;
-    private BigDecimal lopr;
-
-    private Long trqu;
-    private BigDecimal trPrc;
-    private BigDecimal lstgMrktTotAmt;
-
-    private String basPntm;
-    private BigDecimal basIdx;
+public record IndexDataApiResponse(
+        String basDt,
+        String idxNm,
+        String idxCsf,
+        Integer epyItmsCnt,
+        BigDecimal clpr,
+        BigDecimal vs,
+        BigDecimal fltRt,
+        BigDecimal mkp,
+        BigDecimal hipr,
+        BigDecimal lopr,
+        Long trqu,
+        BigDecimal trPrc,
+        BigDecimal lstgMrktTotAmt,
+        String basPntm,
+        BigDecimal basIdx
+) {
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/IndexDataApiResponse.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/IndexDataApiResponse.java
@@ -1,0 +1,31 @@
+package com.sprint.mission.findex.domain.syncclient.dto;
+
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class IndexDataApiResponse {
+
+    private String basDt;
+    private String idxNm;
+    private String idxCsf;
+    private Integer epyItmsCnt;
+
+    private BigDecimal clpr;
+    private BigDecimal vs;
+    private BigDecimal fltRt;
+    private BigDecimal mkp;
+    private BigDecimal hipr;
+    private BigDecimal lopr;
+
+    private Long trqu;
+    private BigDecimal trPrc;
+    private BigDecimal lstgMrktTotAmt;
+
+    private String basPntm;
+    private BigDecimal basIdx;
+}

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxApiResponseWrapper.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxApiResponseWrapper.java
@@ -1,10 +1,6 @@
 package com.sprint.mission.findex.domain.syncclient.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-public class KrxApiResponseWrapper {
-    private KrxResponse response;
+public record KrxApiResponseWrapper(
+        KrxResponse response
+) {
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxApiResponseWrapper.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxApiResponseWrapper.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.findex.domain.syncclient.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KrxApiResponseWrapper {
+    private KrxResponse response;
+}

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxItems.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxItems.java
@@ -2,11 +2,11 @@ package com.sprint.mission.findex.domain.syncclient.dto;
 
 import java.util.Collections;
 import java.util.List;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class KrxItems {
-    private List<IndexDataApiResponse> item = Collections.emptyList();
+public record KrxItems(
+        List<IndexDataApiResponse> item
+) {
+    public KrxItems {
+        item = item == null ? Collections.emptyList() : item;
+    }
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxItems.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxItems.java
@@ -1,0 +1,12 @@
+package com.sprint.mission.findex.domain.syncclient.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class KrxItems {
+    private List<IndexDataApiResponse> item;
+}

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxItems.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxItems.java
@@ -1,12 +1,12 @@
 package com.sprint.mission.findex.domain.syncclient.dto;
 
+import java.util.Collections;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
 public class KrxItems {
-    private List<IndexDataApiResponse> item;
+    private List<IndexDataApiResponse> item = Collections.emptyList();
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponse.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponse.java
@@ -1,12 +1,7 @@
 package com.sprint.mission.findex.domain.syncclient.dto;
 
-
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-public class KrxResponse {
-    private KrxResponseHeader header;
-    private KrxResponseBody body;
+public record KrxResponse(
+        KrxResponseHeader header,
+        KrxResponseBody body
+) {
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponse.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponse.java
@@ -1,0 +1,12 @@
+package com.sprint.mission.findex.domain.syncclient.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KrxResponse {
+    private KrxResponseHeader header;
+    private KrxResponseBody body;
+}

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponseBody.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponseBody.java
@@ -1,14 +1,9 @@
 package com.sprint.mission.findex.domain.syncclient.dto;
 
-import jakarta.persistence.criteria.CriteriaBuilder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-public class KrxResponseBody {
-    private Integer numOfRows;
-    private Integer pageNo;
-    private Integer totalCount;
-    private KrxItems items;
+public record KrxResponseBody(
+        Integer numOfRows,
+        Integer pageNo,
+        Integer totalCount,
+        KrxItems items
+) {
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponseBody.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponseBody.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.findex.domain.syncclient.dto;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KrxResponseBody {
+    private Integer numOfRows;
+    private Integer pageNo;
+    private Integer totalCount;
+    private KrxItems items;
+}

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponseHeader.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponseHeader.java
@@ -1,0 +1,12 @@
+package com.sprint.mission.findex.domain.syncclient.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KrxResponseHeader {
+    private String resultCode;
+    private String resultMsg;
+}

--- a/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponseHeader.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncclient/dto/KrxResponseHeader.java
@@ -1,12 +1,7 @@
 package com.sprint.mission.findex.domain.syncclient.dto;
 
-
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-public class KrxResponseHeader {
-    private String resultCode;
-    private String resultMsg;
+public record KrxResponseHeader(
+        String resultCode,
+        String resultMsg
+) {
 }


### PR DESCRIPTION
## 관련 이슈

- Closes #13 

## PR 유형

- [x] feat: 새로운 기능
- [ ] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가·수정
- [ ] deploy: 배포 관련
- [ ] chore: 빌드·설정 변경

## 작업 내용

- 금융위원회 지수시세 Open API 클라이언트 인터페이스 및 구현체 추가
- Open API 응답 매핑용 DTO 및 응답 래퍼 DTO 추가
- 환경변수 기반 API 키 / base-url 설정 및 실제 외부 API 호출 동작 확인

## 테스트 내용

- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 해당 없음

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [ ] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- 현재 구현은 외부 API가 `idxNm`(지수명) 파라미터를 사용해서 `indexName` 기준으로 작성했습니다.
- `indexName`은 구현이 단순하고 외부 API와 바로 연결되는 장점이 있습니다.
- `indexCode`는 공통 계약 의미가 더 명확하고 내부 식별자로 확장하기 좋다는 장점이 있습니다.
- 공통 클라이언트 계약을 어떤 기준으로 가져가는 게 좋을지 의견 부탁드립니다.

## 스크린샷 / 참고 자료

- 금융위원회 지수시세 Open API 실제 호출 및 응답(JSON) 확인 완료
- 로컬 실행 환경에서 `fetchByDateRange("코스피", 2024-07-01 ~ 2024-07-31)` 테스트 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 날짜 범위로 주식시장 지수 데이터를 조회하고 페이징된 결과를 자동으로 수집하는 외부 API 연동이 추가되었습니다.
  * 종가·변동률·거래량 등 지수 항목을 반환하는 안정적 데이터 모델이 도입되었습니다.
* **버그 수정 / 안정성**
  * 입력 검증과 예외 처리가 강화되어 잘못된 요청이나 외부 호출 실패 시 일관된 오류 응답을 제공합니다.
* **잡무**
  * 코드 형식(공백·개행) 정리가 일부 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->