### PR TITLE
fix: base_point_in_time 컬럼 타입 VARCHAR → DATE 수정

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/entity/IndexInfo.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/entity/IndexInfo.java
@@ -30,7 +30,7 @@ public class IndexInfo extends BaseUpdatableEntity {
   @Column(name = "employed_items_count", nullable = false)
   private Integer employedItemsCount;
 
-  @Column(name = "base_point_in_time", nullable = false, length = 50)
+  @Column(name = "base_point_in_time", nullable = false)
   private LocalDate basePointInTime;
 
   @Column(name = "base_index", nullable = false, precision = 20, scale = 4)

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS index_info (
     index_classification VARCHAR(240) NOT NULL,
     index_name           VARCHAR(240) NOT NULL,
     employed_items_count INTEGER      NOT NULL,
-    base_point_in_time   VARCHAR(50)  NOT NULL,
+    base_point_in_time   DATE         NOT NULL,
     base_index           NUMERIC(20, 4) NOT NULL,
     source_type          VARCHAR(10)  NOT NULL CHECK (source_type IN ('USER', 'OPEN_API')),
     favorite             BOOLEAN      NOT NULL DEFAULT FALSE,

--- a/src/main/resources/schema-postgresql.sql
+++ b/src/main/resources/schema-postgresql.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS index_info (
     index_classification VARCHAR(240)   NOT NULL,
     index_name           VARCHAR(240)   NOT NULL,
     employed_items_count INTEGER        NOT NULL,
-    base_point_in_time   VARCHAR(50)    NOT NULL,
+    base_point_in_time   DATE           NOT NULL,
     base_index           NUMERIC(20, 4) NOT NULL,
     source_type          VARCHAR(10)    NOT NULL CHECK (source_type IN ('USER', 'OPEN_API')),
     favorite             BOOLEAN        NOT NULL DEFAULT FALSE,


### PR DESCRIPTION
## 관련 이슈

- Closes #28 

## PR 유형

- [x] fix: 버그 수정

## 작업 내용

- `index_info.base_point_in_time` 컬럼 타입 `VARCHAR(50)` → `DATE` 수정 (schema-h2.sql, schema-postgresql.sql)

## 테스트 내용

- [x] 로컬 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- 해당 없음

## 스크린샷 / 참고 자료

- 해당 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 기본 시점 날짜 필드의 데이터 타입을 문자열에서 날짜 형식으로 개선하여 데이터 저장 및 검증의 정확성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->