### PR TITLE
fix: sync_job FK ON DELETE CASCADE 추가

### DIFF
--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS sync_job (
     job_time      TIMESTAMP    NOT NULL,
     result        VARCHAR(10)  NOT NULL CHECK (result IN ('SUCCESS', 'FAILED')),
     error_message TEXT,
-    FOREIGN KEY (index_info_id) REFERENCES index_info (id)
+    FOREIGN KEY (index_info_id) REFERENCES index_info (id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS auto_sync_config (

--- a/src/main/resources/schema-postgresql.sql
+++ b/src/main/resources/schema-postgresql.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS sync_job (
     job_time      TIMESTAMPTZ  NOT NULL,
     result        VARCHAR(10)  NOT NULL CHECK (result IN ('SUCCESS', 'FAILED')),
     error_message TEXT,
-    FOREIGN KEY (index_info_id) REFERENCES index_info (id)
+    FOREIGN KEY (index_info_id) REFERENCES index_info (id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS auto_sync_config (


### PR DESCRIPTION
## 관련 이슈

- Closes #43 

## PR 유형

- [x] fix: 버그 수정

## 작업 내용

- `sync_job.index_info_id` FK에 `ON DELETE CASCADE` 추가 (schema-h2.sql, schema-postgresql.sql)

## 테스트 내용

- [x] 로컬 테스트 완료
- [ ] 해당 없음

## 체크리스트

- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [ ] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- 해당 없음

## 스크린샷 / 참고 자료

- 관련 ADR: #24, #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 데이터베이스 스키마 업데이트로 데이터 무결성 개선: 인덱스 정보 삭제 시 관련된 동기화 작업 기록이 자동으로 정리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->