### PR TITLE
feat: 지수 정보 요약 목록 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ HELP.md
 CLAUDE.md
 .claude
 .gradle
-.claude
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/controller/IndexInfoController.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/controller/IndexInfoController.java
@@ -4,11 +4,13 @@ import com.sprint.mission.findex.domain.indexinfo.controller.api.IndexInfoApi;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoQueryCondition;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoResponse;
+import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoSummaryResponse;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
 import com.sprint.mission.findex.domain.indexinfo.service.IndexInfoService;
 import com.sprint.mission.findex.global.common.dto.CursorPageResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -67,5 +69,12 @@ public class IndexInfoController implements IndexInfoApi {
     CursorPageResponse<IndexInfoResponse> list = indexInfoService.getList(condition);
     return ResponseEntity.status(HttpStatus.OK)
         .body(list);
+  }
+
+  @GetMapping(path = "summaries")
+  public ResponseEntity<List<IndexInfoSummaryResponse>> getSummaries() {
+    List<IndexInfoSummaryResponse> summaries = indexInfoService.getSummaries();
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(summaries);
   }
 }

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/controller/api/IndexInfoApi.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/controller/api/IndexInfoApi.java
@@ -3,6 +3,7 @@ package com.sprint.mission.findex.domain.indexinfo.controller.api;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoQueryCondition;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoResponse;
+import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoSummaryResponse;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
 import com.sprint.mission.findex.global.common.dto.CursorPageResponse;
 import com.sprint.mission.findex.global.exception.ErrorResponse;
@@ -14,6 +15,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import java.util.List;
 import java.util.UUID;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -64,6 +67,15 @@ public interface IndexInfoApi {
   ResponseEntity<Void> delete(
       @Parameter(description = "지수 정보 ID", schema = @Schema(type = "string", format = "uuid"))
       @PathVariable UUID id);
+
+  @Operation(summary = "지수 정보 요약 목록 조회", description = "지수 ID, 분류, 이름만 포함한 전체 지수 목록을 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "지수 정보 요약 목록 조회 성공",
+          content = @Content(array = @ArraySchema(schema = @Schema(implementation = IndexInfoSummaryResponse.class)))),
+      @ApiResponse(responseCode = "500", description = "서버 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  ResponseEntity<List<IndexInfoSummaryResponse>> getSummaries();
 
   @Operation(summary = "지수 정보 목록 조회", description = "지수 정보 목록을 조회합니다. 필터링, 정렬, 커서 기반 페이지네이션을 지원합니다.")
   @ApiResponses({

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/dto/IndexInfoSummaryResponse.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/dto/IndexInfoSummaryResponse.java
@@ -1,10 +1,17 @@
 package com.sprint.mission.findex.domain.indexinfo.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 
+@Schema(description = "지수 정보 요약 Response")
 public record IndexInfoSummaryResponse(
+    @Schema(description = "지수 정보 ID", example = "550e8400-e29b-41d4-a716-446655440000")
     UUID id,
+
+    @Schema(description = "지수 분류명", example = "KOSPI시리즈")
     String indexClassification,
+
+    @Schema(description = "지수명", example = "IT 서비스")
     String indexName
 ) {
 

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/dto/IndexInfoSummaryResponse.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/dto/IndexInfoSummaryResponse.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.findex.domain.indexinfo.dto;
+
+import java.util.UUID;
+
+public record IndexInfoSummaryResponse(
+    UUID id,
+    String indexClassification,
+    String indexName
+) {
+
+}

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/querydsl/IndexInfoCustomRepository.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/querydsl/IndexInfoCustomRepository.java
@@ -2,9 +2,13 @@ package com.sprint.mission.findex.domain.indexinfo.repository.querydsl;
 
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoQueryCondition;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoResponse;
+import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoSummaryResponse;
 import com.sprint.mission.findex.global.common.dto.CursorPageResponse;
+import java.util.List;
 
 public interface IndexInfoCustomRepository {
 
   CursorPageResponse<IndexInfoResponse> findIndexInfos(IndexInfoQueryCondition condition);
+
+  List<IndexInfoSummaryResponse> findIndexInfoSummaries();
 }

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/querydsl/impl/IndexInfoCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/querydsl/impl/IndexInfoCustomRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoQueryCondition;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoResponse;
+import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoSummaryResponse;
 import com.sprint.mission.findex.domain.indexinfo.repository.querydsl.IndexInfoCustomRepository;
 import com.sprint.mission.findex.global.common.dto.CursorPageResponse;
 import java.util.List;
@@ -25,6 +26,19 @@ import org.springframework.stereotype.Repository;
 public class IndexInfoCustomRepositoryImpl implements IndexInfoCustomRepository {
 
   private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<IndexInfoSummaryResponse> findIndexInfoSummaries() {
+    return queryFactory
+        .select(Projections.constructor(
+            IndexInfoSummaryResponse.class,
+            indexInfo.id,
+            indexInfo.indexClassification,
+            indexInfo.indexName
+        ))
+        .from(indexInfo)
+        .fetch();
+  }
 
   @Override
   public CursorPageResponse<IndexInfoResponse> findIndexInfos(IndexInfoQueryCondition condition) {

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/service/IndexInfoService.java
@@ -8,6 +8,7 @@ import com.sprint.mission.findex.domain.autosyncconfig.repository.AutoSyncConfig
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoQueryCondition;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoResponse;
+import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoSummaryResponse;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
 import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
 import com.sprint.mission.findex.domain.indexinfo.entity.SourceType;
@@ -15,7 +16,7 @@ import com.sprint.mission.findex.domain.indexinfo.mapper.IndexInfoMapper;
 import com.sprint.mission.findex.domain.indexinfo.repository.IndexInfoRepository;
 import com.sprint.mission.findex.global.common.dto.CursorPageResponse;
 import com.sprint.mission.findex.global.exception.ApiException;
-import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -74,6 +75,10 @@ public class IndexInfoService {
 
   public CursorPageResponse<IndexInfoResponse> getList(IndexInfoQueryCondition condition) {
     return indexInfoRepository.findIndexInfos(condition);
+  }
+
+  public List<IndexInfoSummaryResponse> getSummaries() {
+    return this.indexInfoRepository.findIndexInfoSummaries();
   }
 
   private IndexInfo create(IndexInfoCreateRequest req, SourceType sourceType) {


### PR DESCRIPTION
## 관련 이슈

- Closes #57

## PR 유형

- [x] feat: 새로운 기능

## 작업 내용

- `GET /api/index-infos/summaries` 지수 정보 요약 목록 조회 API 구현
- `IndexInfoSummaryResponse` DTO 생성 (id, indexClassification, indexName)
- Querydsl `Projections.constructor` 기반 `findIndexInfoSummaries()` 구현

## 테스트 내용

- [x] 로컬 테스트 완료
- [x] API 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.

## 리뷰 포인트

- 단순 전체 조회임에도 타입 안전성을 위해 Spring Data JPA Projection 대신 Querydsl `Projections.constructor`를 선택했습니다. 더 나은 방법이 있다면 피드백 부탁드립니다.

## 스크린샷 / 참고 자료
- postman 이용 100개의 지수 정보 데이터 생성 후, 프런트 페이지에서 응답 확인
<img width="1440" height="663" alt="스크린샷 2026-04-17 오후 11 28 18" src="https://github.com/user-attachments/assets/67d09086-3e74-41b1-9f88-d37581a33823" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인덱스 정보 요약 목록을 조회할 수 있는 새로운 API 엔드포인트 추가. ID, 분류, 이름 정보가 포함된 요약 데이터를 반환합니다.

* **Chores**
  * 설정 파일에서 중복된 항목 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->