### PR TITLE
fix: SyncJobService 내부 호출로 인한 트랜잭션 무력화 문제 해결

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/mapper/SyncJobMapper.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/mapper/SyncJobMapper.java
@@ -1,0 +1,18 @@
+package com.sprint.mission.findex.domain.syncjob.mapper;
+
+import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
+import com.sprint.mission.findex.domain.syncjob.dto.SyncJobResponse;
+import com.sprint.mission.findex.domain.syncjob.entity.JobResult;
+import com.sprint.mission.findex.domain.syncjob.entity.JobType;
+import com.sprint.mission.findex.domain.syncjob.entity.SyncJob;
+import java.time.LocalDate;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface SyncJobMapper {
+  @Mapping(target = "worker", source = "workerIp")
+  @Mapping(target = "errorMessage", source = "logMessage")
+  SyncJob toEntity(IndexInfo indexInfo, JobType jobType, LocalDate targetDate, String workerIp, JobResult result, String logMessage);
+  SyncJobResponse toResponse(SyncJob syncJob);
+}

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/mapper/SyncJobMapper.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/mapper/SyncJobMapper.java
@@ -14,5 +14,6 @@ public interface SyncJobMapper {
   @Mapping(target = "worker", source = "workerIp")
   @Mapping(target = "errorMessage", source = "logMessage")
   SyncJob toEntity(IndexInfo indexInfo, JobType jobType, LocalDate targetDate, String workerIp, JobResult result, String logMessage);
+  @Mapping(target = "indexInfoId", source = "indexInfo.id")
   SyncJobResponse toResponse(SyncJob syncJob);
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexDataSyncProcessor.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexDataSyncProcessor.java
@@ -8,7 +8,7 @@ import com.sprint.mission.findex.domain.syncjob.entity.JobResult;
 import com.sprint.mission.findex.domain.syncjob.entity.JobType;
 import com.sprint.mission.findex.domain.syncjob.entity.SyncJob;
 import com.sprint.mission.findex.domain.syncjob.repository.SyncJobRepository;
-import com.sprint.mission.findex.domain.syncjob.mapper.SyncJobMapper; // 🚨 본인 패키지 경로에 맞게 확인해줘!
+import com.sprint.mission.findex.domain.syncjob.mapper.SyncJobMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexDataSyncProcessor.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexDataSyncProcessor.java
@@ -1,0 +1,45 @@
+package com.sprint.mission.findex.domain.syncjob.service;
+
+import com.sprint.mission.findex.domain.indexdata.entity.IndexData;
+import com.sprint.mission.findex.domain.indexdata.repository.IndexDataRepository;
+import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
+import com.sprint.mission.findex.domain.syncjob.dto.SyncJobResponse;
+import com.sprint.mission.findex.domain.syncjob.entity.JobResult;
+import com.sprint.mission.findex.domain.syncjob.entity.JobType;
+import com.sprint.mission.findex.domain.syncjob.entity.SyncJob;
+import com.sprint.mission.findex.domain.syncjob.repository.SyncJobRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class IndexDataSyncProcessor {
+
+  private final IndexDataRepository indexDataRepository;
+  private final SyncJobRepository syncJobRepository;
+
+  @Transactional
+  public SyncJobResponse saveIndexDataAndHistory(
+      List<IndexData> indexDataList, IndexInfo indexInfo, LocalDate targetDate,
+      String workerIp, String logMessage) {
+
+    if (indexDataList != null && !indexDataList.isEmpty()) {
+      indexDataRepository.saveAll(indexDataList);
+    }
+
+    SyncJob syncJob = SyncJob.builder()
+        .indexInfo(indexInfo)
+        .jobType(JobType.INDEX_DATA)
+        .targetDate(targetDate)
+        .worker(workerIp)
+        .result(JobResult.SUCCESS)
+        .errorMessage(logMessage)
+        .build();
+
+    return SyncJobResponse.from(syncJobRepository.save(syncJob));
+  }
+}

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexDataSyncProcessor.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexDataSyncProcessor.java
@@ -8,6 +8,7 @@ import com.sprint.mission.findex.domain.syncjob.entity.JobResult;
 import com.sprint.mission.findex.domain.syncjob.entity.JobType;
 import com.sprint.mission.findex.domain.syncjob.entity.SyncJob;
 import com.sprint.mission.findex.domain.syncjob.repository.SyncJobRepository;
+import com.sprint.mission.findex.domain.syncjob.mapper.SyncJobMapper; // 🚨 본인 패키지 경로에 맞게 확인해줘!
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,25 +22,24 @@ public class IndexDataSyncProcessor {
 
   private final IndexDataRepository indexDataRepository;
   private final SyncJobRepository syncJobRepository;
+  private final SyncJobMapper syncJobMapper;
 
   @Transactional
   public SyncJobResponse saveIndexDataAndHistory(
-      List<IndexData> indexDataList, IndexInfo indexInfo, LocalDate targetDate,
-      String workerIp, String logMessage) {
+      List<IndexData> indexDataList,
+      IndexInfo indexInfo,
+      LocalDate targetDate,
+      String workerIp,
+      String logMessage) {
 
     if (indexDataList != null && !indexDataList.isEmpty()) {
       indexDataRepository.saveAll(indexDataList);
     }
 
-    SyncJob syncJob = SyncJob.builder()
-        .indexInfo(indexInfo)
-        .jobType(JobType.INDEX_DATA)
-        .targetDate(targetDate)
-        .worker(workerIp)
-        .result(JobResult.SUCCESS)
-        .errorMessage(logMessage)
-        .build();
+    SyncJob syncJob = syncJobMapper.toEntity(
+        indexInfo, JobType.INDEX_DATA, targetDate, workerIp, JobResult.SUCCESS, logMessage
+    );
 
-    return SyncJobResponse.from(syncJobRepository.save(syncJob));
+    return syncJobMapper.toResponse(syncJobRepository.save(syncJob));
   }
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -40,6 +40,7 @@ public class SyncJobService {
   private final KrxOpenApiClient krxOpenApiClient;
   private final IndexDataMapper indexDataMapper;
   private final IndexInfoSyncProcessor indexInfoSyncProcessor;
+  private final IndexDataSyncProcessor indexDataSyncProcessor;
 
   public List<SyncJobResponse> syncIndexInfos(LocalDate targetDate, String workerIp) {
     List<IndexDataApiResponse> responses = krxOpenApiClient.fetchByDate(targetDate);
@@ -96,12 +97,11 @@ public class SyncJobService {
         );
 
         int dataSize = (externalDataList != null) ? externalDataList.size() : 0;
-
         LocalDate actualTargetDate = baseDateTo;
+        List<IndexData> indexDataList = null;
 
         if (dataSize > 0) {
-          List<IndexData> indexDataList = indexDataMapper.toEntityList(externalDataList, indexInfo);
-          saveData(indexDataList);
+          indexDataList = indexDataMapper.toEntityList(externalDataList, indexInfo);
 
           actualTargetDate = indexDataList.stream()
               .map(IndexData::getBaseDate)
@@ -113,7 +113,9 @@ public class SyncJobService {
             ? null
             : String.format("범위 연동: %s ~ %s (%d건)", baseDateFrom, baseDateTo, dataSize);
 
-        results.add(saveSyncJobHistory(indexInfo, JobType.INDEX_DATA, actualTargetDate, workerIp, JobResult.SUCCESS, logMessage));
+        results.add(indexDataSyncProcessor.saveIndexDataAndHistory(
+            indexDataList, indexInfo, actualTargetDate, workerIp, logMessage));
+
         log.info("[Sync 성공] 지수: {}, 요청범위: {} ~ {} -> 실제연동기준일: {} ({}건)",
             indexInfo.getIndexName(), baseDateFrom, baseDateTo, actualTargetDate, dataSize);
 
@@ -140,11 +142,6 @@ public class SyncJobService {
       int size) {
 
     return syncJobRepository.searchSyncJobPage(condition, cursor, idAfter, sortField, sortDirection, size);
-  }
-
-  @Transactional
-  protected void saveData(List<IndexData> indexDataList) {
-    indexDataRepository.saveAll(indexDataList);
   }
 
   private IndexInfoCreateRequest toCreateRequest(IndexDataApiResponse response) {


### PR DESCRIPTION
## 관련 이슈

- Closes #68

## PR 유형

- [x] fix: 버그 수정
- [x] refactor: 코드 리팩토링

## 작업 내용

- 트랜잭션 Self-invocation(내부 호출) 문제 해결: 동일 클래스 내 메서드 호출로 인해 @Transactional이 무시되던 현상을 해결하기 위해 IndexDataSyncProcessor 분리
- 불필요한 saveData() 메서드 제거: 프록시를 정상적으로 타지 않는 기존 SyncJobService 내부의 saveData() 메서드 삭제

## 테스트 내용

- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [x] 해당 없음: 트랜잭션 프록시 메커니즘(AOP)에 기반하여 외부 빈(Bean) 호출로 구조를 변경하였으므로, 이론적으로 롤백이 보장되는 구조임을 확인했습니다.

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 인덱스 데이터 동기화 로직을 재구성하여 데이터 저장과 동기화 이력 기록 책임을 분리했습니다.
  * 동기화 흐름이 단일 처리기로 위임되어 상태 처리와 오류 메시지 기록이 더 일관되게 이루어집니다.

* **New Features**
  * 동기화 시 데이터 저장과 이력 생성이 하나의 트랜잭션으로 수행되어 안정성과 일관성이 향상되었습니다.
  * 동기화 이력 항목 생성 및 응답 변환 기능이 추가되어 작업 추적이 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->