### PR TITLE
fix: 즐겨찾기 성과 조회 API N+1 이슈 수정 및 상수명 정리

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardPerformanceService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardPerformanceService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -22,16 +21,13 @@ import java.util.Objects;
 @Transactional(readOnly = true)
 public class DashboardPerformanceService {
 
-    private static final LocalDate Min_Date = LocalDate.of(1900, 1, 1);
-
     private final IndexInfoRepository indexInfoRepository;
     private final IndexDataRepository indexDataRepository;
 
     public List<IndexPerformanceResponse> getFavoriteIndexPerformance(
             IndexPerformancePeriodType periodType
     ) {
-        return indexInfoRepository.findAll().stream()
-                .filter(indexInfo -> indexInfo.getFavorite())
+        return indexInfoRepository.findAllByFavoriteTrue().stream()
                 .map(indexInfo -> toIndexPerformance(indexInfo, periodType))
                 .filter(Objects::nonNull)
                 .toList();
@@ -41,23 +37,22 @@ public class DashboardPerformanceService {
         IndexInfo indexInfo,
         IndexPerformancePeriodType periodType
     ) {
-        List<IndexData> indexDataList = indexDataRepository.findByIndexInfoIdAndBaseDateBetween(
-                indexInfo.getId(),
-                Min_Date,
-                LocalDate.now()
-        );
+        IndexData currentData = indexDataRepository
+                .findFirstByIndexInfoIdOrderByBaseDateDesc(indexInfo.getId())
+                .orElse(null);
 
-        if (indexDataList.isEmpty()) {
+        if (currentData == null) {
             return null;
         }
 
-        List<IndexData> sorted = indexDataList.stream()
-                .sorted(Comparator.comparing(IndexData::getBaseDate).reversed())
-                .toList();
-
-        IndexData currentData = sorted.get(0);
         LocalDate targetDate = getTargetDate(currentData.getBaseDate(), periodType);
-        IndexData beforeData = findClosestBeforeOrEqual(sorted, targetDate);
+
+        IndexData beforeData = indexDataRepository
+                .findFirstByIndexInfoIdAndBaseDateLessThanEqualOrderByBaseDateDesc(
+                        indexInfo.getId(),
+                        targetDate
+                )
+                .orElse(null);
 
         if (beforeData == null) {
             return null;
@@ -85,15 +80,6 @@ public class DashboardPerformanceService {
             case WEEKLY -> currentDate.minusWeeks(1);
             case MONTHLY -> currentDate.minusMonths(1);
         };
-    }
-
-    private IndexData findClosestBeforeOrEqual(List<IndexData> sorted, LocalDate targetDate) {
-        for (IndexData indexData : sorted) {
-            if (!indexData.getBaseDate().isAfter(targetDate)) {
-                return indexData;
-            }
-        }
-        return null;
     }
 
     private BigDecimal calculateFluctuationRate(

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/IndexInfoRepository.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/IndexInfoRepository.java
@@ -3,6 +3,7 @@ package com.sprint.mission.findex.domain.indexinfo.repository;
 import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
 import com.sprint.mission.findex.domain.indexinfo.repository.querydsl.IndexInfoCustomRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,6 @@ public interface IndexInfoRepository extends JpaRepository<IndexInfo, UUID>,
   boolean existsByIndexClassificationAndIndexName(String indexClassification, String indexName);
 
   Optional<IndexInfo> findByIndexClassificationAndIndexName(String indexClassification, String indexName);
+
+  List<IndexInfo> findAllByFavoriteTrue();
 }


### PR DESCRIPTION
## 관련 이슈

- Closes #72 

## PR 유형

- [x] fix: 버그 수정

## 작업 내용

- 즐겨찾기 성과 조회 API에서 전체 'IndexInfo' 조회 후 애플리케이션에서 즐겨찾기 필터링하던 구조를 'findAllByFavoriteTrue()' 기반으로 변경
- 각 즐겨찾기 지수별 전체 이력 조회 대신, 최신 데이터 1건과 기준 시점 이전 최근 데이터 1건만 조회하도록 수정
- 기존 'Min_Date' 상수를 제거하여 관련 컨벤션 이슈를 함께 정리

## 테스트 내용

- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 해당 없음

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- 즐겨찾기 성과 조회 API의 기존 전체 조회 구조를 최소 조회 방식으로 변경한 부분을 중점으로 확인해주시면 감사드리겠습니다.
- 지수별 개별 조회 구조 자체를 더 줄이는 IN 절 / JOIN 기반 일괄 조회 최적화는 후속 트러블슈팅 포인트로 봐야할 것 같습니다.

## 스크린샷 / 참고 자료

- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 즐겨찾기 데이터 조회 성능을 최적화했습니다.
  * 대시보드의 인덱스 성능 데이터 검색 효율을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->