### PR TITLE
fix: GlobalExceptionHandler 서버 로그 누락

### DIFF
--- a/src/main/java/com/sprint/mission/findex/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprint/mission/findex/global/exception/GlobalExceptionHandler.java
@@ -4,17 +4,20 @@ import static com.sprint.mission.findex.global.exception.ApiException.ERROR.*;
 
 import com.sprint.mission.findex.global.exception.ApiException.ERROR;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
   @ExceptionHandler(ApiException.class)
   public ResponseEntity<ErrorResponse> handleApiException(ApiException e) {
     ERROR error = e.getError();
+    log.warn("[ApiException] {} status: {}, code: {}, message: {}", error.name(), error.getHttpStatus().value(), error.getCode(), error.getMessage());
     return ResponseEntity
         .status(error.getHttpStatus())
         .body(ErrorResponse.of(
@@ -31,6 +34,7 @@ public class GlobalExceptionHandler {
     String details = e.getBindingResult().getFieldErrors().stream()
         .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
         .collect(Collectors.joining(", "));
+    log.warn("[ApiException] {} status: {}, code: {}, message: {} | {}", error.name(), error.getHttpStatus().value(), error.getCode(), error.getMessage(), details);
     return ResponseEntity
         .status(error.getHttpStatus())
         .body(ErrorResponse.of(
@@ -43,6 +47,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleException(Exception e) {
     ERROR error = COMMON_UNEXPECTED_ERROR;
+    log.error("[UnexpectedException] ", e);
     return ResponseEntity
         .status(error.getHttpStatus())
         .body(ErrorResponse.of(


### PR DESCRIPTION
## 관련 이슈

- Closes #81

## PR 유형

- [x] fix: 버그 수정

## 작업 내용

- `@Slf4j` 추가
- `ApiException` 처리 시 `log.warn` 추가 (enum명, status, code, message)
- `MethodArgumentNotValidException` 처리 시 `log.warn` 추가 (ApiException 양식 + 필드 오류 상세)
- 의도치 않은 `Exception` 처리 시 `log.error` 추가 (스택 트레이스 포함)

## 테스트 내용

- [x] 로컬 테스트 완료
- [x] API 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- 로그 레벨 기준 적절한지 확인 (비즈니스 예외 warn / 의도치 않은 예외 error)
- ValidationException 로그 포맷이 ApiException 양식과 일치하는지 확인

## 스크린샷 / 참고 자료

**테스트 시나리오 (3가지)**

1. 존재하지 않는 UUID로 DELETE 요청 → `ApiException` WARN (INDEX_INFO_NOT_FOUND, 404)
2. cursor만 전달 (idAfter 없음) → `ValidationException` WARN (COMMON_INVALID_REQUEST, 400) + 필드 상세
3. 잘못된 UUID 형식 입력 → `UnexpectedException` ERROR + 스택 트레이스
<img width="1440" height="401" alt="스크린샷 2026-04-21 오후 12 29 33" src="https://github.com/user-attachments/assets/60bf7c16-4641-4abe-af74-a179371da5a4" />
