### PR TITLE
feat: 서비스 배포 주소 CORS 설정 추가

### DIFF
--- a/src/main/java/com/sprint/mission/findex/global/config/WebConfig.java
+++ b/src/main/java/com/sprint/mission/findex/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.sprint.mission.findex.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/api/**")
+        .allowedOrigins(
+            "https://findex-by-code-slayers.up.railway.app"
+        )
+        .allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")
+        .allowedHeaders("*")
+        .allowCredentials(true)
+        .maxAge(3600);
+  }
+}

--- a/src/main/java/com/sprint/mission/findex/global/config/WebConfig.java
+++ b/src/main/java/com/sprint/mission/findex/global/config/WebConfig.java
@@ -15,7 +15,6 @@ public class WebConfig implements WebMvcConfigurer {
         )
         .allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")
         .allowedHeaders("*")
-        .allowCredentials(true)
         .maxAge(3600);
   }
 }


### PR DESCRIPTION
## 관련 이슈

- Closes #84

## PR 유형

- [x] feat: 새로운 기능

## 작업 내용

- `global/config/WebConfig.java` 생성 (`WebMvcConfigurer` 구현)
- `/api/**` 경로에 대해 프론트엔드 Railway 도메인 허용
- 허용 메서드: `GET`, `POST`, `PATCH`, `DELETE`, `OPTIONS`
- `allowCredentials(true)`, `maxAge(3600)` 설정

## 테스트 내용

- [x] 로컬 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- `allowedOrigins`에 프론트엔드 Railway 도메인만 명시 (와일드카드 미사용)
- `allowCredentials(true)` 설정 적절한지 확인

## 스크린샷 / 참고 자료

- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * API 엔드포인트에 크로스 오리진 리소스 공유(CORS) 설정이 추가되었습니다.
  * 허용된 단일 도메인에서만 접근을 허용하며, GET·POST·PATCH·DELETE·OPTIONS 메서드를 지원합니다.
  * 모든 요청 헤더를 허용하고 자격 증명(쿠키/인증 헤더)을 전송할 수 있게 구성되었습니다.
  * 브라우저 프리플라이트 응답의 캐시 수명은 3600초로 설정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->