### PR TITLE
fix: 연동 관리 대시보드 요약 수치 0건 노출 및 날짜 필터링 버그 수정

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/dto/SyncJobQueryCondition.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/dto/SyncJobQueryCondition.java
@@ -27,11 +27,11 @@ public record SyncJobQueryCondition(
     @Schema(description = "작업자")
     String worker,
 
-    @Schema(description = "작업 일시 (부터)", example = "2024-04-01")
+    @Schema(description = "작업 일시 (부터)", example = "2026-04-01T00:00:00")
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDate jobTimeFrom,
 
-    @Schema(description = "작업 일시 (까지)", example = "2024-04-10")
+    @Schema(description = "작업 일시 (까지)", example = "2026-04-10T23:59:59")
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDate jobTimeTo,
 

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/dto/SyncJobQueryCondition.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/dto/SyncJobQueryCondition.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.AssertTrue;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "연동 이력 검색 필터")
 public record SyncJobQueryCondition(
@@ -27,9 +28,11 @@ public record SyncJobQueryCondition(
     String worker,
 
     @Schema(description = "작업 일시 (부터)", example = "2024-04-01")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDate jobTimeFrom,
 
     @Schema(description = "작업 일시 (까지)", example = "2024-04-10")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDate jobTimeTo,
 
     @Schema(description = "작업 상태 (SUCCESS, FAILED)")

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/repository/querydsl/impl/SyncJobCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/repository/querydsl/impl/SyncJobCustomRepositoryImpl.java
@@ -58,6 +58,21 @@ public class SyncJobCustomRepositoryImpl implements SyncJobCustomRepository {
         .limit(size + 1L)
         .fetch();
 
+    Long totalElements = queryFactory
+        .select(syncJob.count())
+        .from(syncJob)
+        .where(
+            eqJobType(condition.jobType()),
+            eqIndexInfoId(condition.indexInfoId()),
+            eqStatus(condition.status()),
+            goeBaseDateFrom(condition.baseDateFrom()),
+            loeBaseDateTo(condition.baseDateTo()),
+            containsWorker(condition.worker()),
+            goeJobTimeFrom(condition.jobTimeFrom()),
+            loeJobTimeTo(condition.jobTimeTo())
+        )
+        .fetchOne();
+
     boolean hasNext = syncJobs.size() > size;
 
     List<SyncJobResponse> content = syncJobs.stream()
@@ -84,7 +99,7 @@ public class SyncJobCustomRepositoryImpl implements SyncJobCustomRepository {
         nextCursor,
         nextIdAfter,
         size,
-        null,
+        totalElements,
         hasNext
     );
   }


### PR DESCRIPTION
## 관련 이슈

- Closes #88

## PR 유형

- [x] fix: 버그 수정

## 작업 내용

- SyncJobQueryCondition DTO의 jobTimeFrom, jobTimeTo 필드에 @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") 어노테이션을 추가하여 프론트엔드 연동 규격과 일치시킴 (날짜 필터링 파싱 에러 해결)
- SyncJobCustomRepositoryImpl의 searchSyncJobPage 메서드 내부에 조건에 맞는 전체 개수를 세는 Count 쿼리 추가 (커서 조건 제외)
- CursorPageResponse 반환 시 totalElements에 null 대신 새로 계산된 전체 데이터 개수를 담아 반환하도록 수정 (대시보드 상단 0건 노출 버그 해결)

## 테스트 내용

- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 해당 없음

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 스크린샷 / 참고 자료

<img width="1231" height="663" alt="스크린샷 2026-04-21 140139" src="https://github.com/user-attachments/assets/53f35696-901c-474d-829e-63548d8b6c17" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 날짜 필터의 입력 형식 처리를 강화하여 일시 문자열이 올바르게 파싱되도록 개선했습니다.
  * 페이지형 검색에서 전체 항목 수 집계 로직을 수정해 정확한 페이징 정보를 제공합니다.

* **문서**
  * API 예시의 날짜 표기 예시를 일시(datetime) 형식으로 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->