### PR TITLE
refactor: IndexChartService 이동평균 O(n×k) → O(n) 슬라이딩 윈도우 개선

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardChartService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardChartService.java
@@ -1,5 +1,7 @@
 package com.sprint.mission.findex.domain.dashboard.service;
 
+import static com.sprint.mission.findex.global.exception.ApiException.ERROR.INDEX_INFO_NOT_FOUND;
+
 import com.sprint.mission.findex.domain.dashboard.dto.ChartDataPoint;
 import com.sprint.mission.findex.domain.dashboard.dto.IndexChartPeriodType;
 import com.sprint.mission.findex.domain.dashboard.dto.IndexChartResponse;
@@ -8,10 +10,6 @@ import com.sprint.mission.findex.domain.indexdata.repository.IndexDataRepository
 import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
 import com.sprint.mission.findex.domain.indexinfo.repository.IndexInfoRepository;
 import com.sprint.mission.findex.global.exception.ApiException;
-import org.springframework.transaction.annotation.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
@@ -19,95 +17,87 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
-
-import static com.sprint.mission.findex.global.exception.ApiException.ERROR.INDEX_INFO_NOT_FOUND;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DashboardChartService {
 
-    private final IndexInfoRepository indexInfoRepository;
-    private final IndexDataRepository indexDataRepository;
+  private final IndexInfoRepository indexInfoRepository;
+  private final IndexDataRepository indexDataRepository;
 
-    public IndexChartResponse getIndexChart(
-            UUID id,
-            IndexChartPeriodType periodType
-    ) {
-        IndexInfo indexInfo = indexInfoRepository.findById(id)
-                .orElseThrow(() -> new ApiException(INDEX_INFO_NOT_FOUND));
+  public IndexChartResponse getIndexChart(
+      UUID id,
+      IndexChartPeriodType periodType
+  ) {
+    IndexInfo indexInfo = indexInfoRepository.findById(id)
+        .orElseThrow(() -> new ApiException(INDEX_INFO_NOT_FOUND));
 
-        LocalDate fromDate = getFromDate(periodType);
+    LocalDate fromDate = getFromDate(periodType);
 
-        List<IndexData> sortedIndexData = indexDataRepository
-                .findByIndexInfoIdAndBaseDateBetween(id, fromDate, LocalDate.now())
-                .stream()
-                .sorted(Comparator.comparing(IndexData::getBaseDate))
-                .toList();
+    List<IndexData> sortedIndexData = indexDataRepository
+        .findByIndexInfoIdAndBaseDateBetween(id, fromDate, LocalDate.now())
+        .stream()
+        .sorted(Comparator.comparing(IndexData::getBaseDate))
+        .toList();
 
-        List<ChartDataPoint> dataPoints = toChartDataPoints(sortedIndexData);
-        List<ChartDataPoint> ma5DataPoints = calculateMovingAverage(sortedIndexData, 5);
-        List<ChartDataPoint> ma20DataPoints = calculateMovingAverage(sortedIndexData, 20);
+    List<ChartDataPoint> dataPoints = toChartDataPoints(sortedIndexData);
+    List<ChartDataPoint> ma5DataPoints = calculateMovingAverage(sortedIndexData, 5);
+    List<ChartDataPoint> ma20DataPoints = calculateMovingAverage(sortedIndexData, 20);
 
-        return new IndexChartResponse(
-                indexInfo.getId(),
-                indexInfo.getIndexClassification(),
-                indexInfo.getIndexName(),
-                periodType,
-                dataPoints,
-                ma5DataPoints,
-                ma20DataPoints
-        );
+    return new IndexChartResponse(
+        indexInfo.getId(),
+        indexInfo.getIndexClassification(),
+        indexInfo.getIndexName(),
+        periodType,
+        dataPoints,
+        ma5DataPoints,
+        ma20DataPoints
+    );
+  }
+
+  private LocalDate getFromDate(IndexChartPeriodType periodType) {
+    LocalDate today = LocalDate.now();
+
+    return switch (periodType) {
+      case MONTHLY -> today.minusMonths(1);
+      case QUARTERLY -> today.minusMonths(3);
+      case YEARLY -> today.minusYears(1);
+    };
+  }
+
+  private List<ChartDataPoint> toChartDataPoints(List<IndexData> sortedIndexData) {
+    return sortedIndexData.stream()
+        .map(indexData -> new ChartDataPoint(
+            indexData.getBaseDate(),
+            indexData.getClosingPrice()
+        ))
+        .toList();
+  }
+
+  private List<ChartDataPoint> calculateMovingAverage(
+      List<IndexData> sortedIndexData,
+      int windowSize
+  ) {
+    List<ChartDataPoint> result = new ArrayList<>();
+    BigDecimal winSum = BigDecimal.ZERO;
+    int i;
+    // 초기 윈도우 채우기: 첫 번째 MA 계산에 필요한 windowSize-1개 선합산
+    for (i = 0; i < windowSize - 1 && i < sortedIndexData.size(); i++) {
+      winSum = winSum.add(sortedIndexData.get(i).getClosingPrice());
     }
-
-    private LocalDate getFromDate(IndexChartPeriodType periodType) {
-        LocalDate today = LocalDate.now();
-
-        return switch (periodType) {
-            case MONTHLY -> today.minusMonths(1);
-            case QUARTERLY -> today.minusMonths(3);
-            case YEARLY -> today.minusYears(1);
-        };
+    // 슬라이딩 윈도우: 새 값 추가 → MA 계산 → 가장 오래된 값 제거
+    for (; i < sortedIndexData.size(); i++) {
+      winSum = winSum.add(sortedIndexData.get(i).getClosingPrice());
+      result.add(new ChartDataPoint(
+          sortedIndexData.get(i).getBaseDate(),
+          winSum.divide(BigDecimal.valueOf(windowSize), 4, RoundingMode.HALF_UP)
+      ));
+      winSum = winSum.subtract(sortedIndexData.get(i - windowSize + 1).getClosingPrice());
     }
-
-    private List<ChartDataPoint> toChartDataPoints(List<IndexData> sortedIndexData) {
-        return sortedIndexData.stream()
-                .map(indexData -> new ChartDataPoint(
-                        indexData.getBaseDate(),
-                        indexData.getClosingPrice()
-                ))
-                .toList();
-    }
-
-    private List<ChartDataPoint> calculateMovingAverage(
-            List<IndexData> sortedIndexData,
-            int windowSize
-    ) {
-        List<ChartDataPoint> result = new ArrayList<>();
-
-        for (int i = 0; i < sortedIndexData.size(); i++) {
-            if (i + 1 < windowSize) {
-                continue;
-            }
-
-            BigDecimal sum = BigDecimal.ZERO;
-
-            for (int j = i - windowSize + 1; j <= i; j++) {
-                sum = sum.add(sortedIndexData.get(j).getClosingPrice());
-            }
-
-            BigDecimal average = sum.divide(
-                    BigDecimal.valueOf(windowSize),
-                    4,
-                    RoundingMode.HALF_UP
-            );
-
-            result.add(new ChartDataPoint(
-                    sortedIndexData.get(i).getBaseDate(),
-                    average
-            ));
-        }
-
-        return result;
-    }
+    return result;
+  }
 }


### PR DESCRIPTION
## 관련 이슈

- Closes #83

## PR 유형

- [x] refactor: 코드 리팩토링

## 작업 내용

- `calculateMovingAverage()` 내부 이중 루프(O(n×k)) → 슬라이딩 윈도우(O(n))로 개선
- 초기 윈도우 채우기(windowSize-1개 선합산) + 슬라이딩 구간 분리
- PR diff에서 수정 전(O(n×k)) / 수정 후(O(n)) 비교 가능

## 테스트 내용

- [x] 로컬 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- 슬라이딩 윈도우 로직 정확성 (초기 구간 skip, 마지막 원소 누락 없는지) 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **Refactor**
  * 대시보드 차트의 이동평균 계산 알고리즘을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->