### PR TITLE
refactor: 지수 연동 예외 처리 흐름 개선 및 감사 로깅 강화

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -107,8 +107,18 @@ public class SyncJobService {
           log.info("[IndexInfo Sync 성공-신규] 지수: {}", response.idxNm());
         } catch (Exception e) {
           String errorMsg = (e.getMessage() != null) ? e.getMessage() : e.getClass().getSimpleName();
-          log.error("[IndexInfo Sync 비정상 흐름] 워크플로우 위반 가능성 탐지 지수명: {} | 사유: {} | 조치: 해당 지수의 사전 등록 여부 및 마스터 데이터 확인 필요",
-              response.idxNm(), errorMsg);
+
+          Optional<IndexInfo> retryExisting = indexInfoRepository.findByIndexClassificationAndIndexName(
+              response.idxCsf(), response.idxNm()
+          );
+
+          if (retryExisting.isPresent()) {
+            log.error("[IndexInfo Sync 실패-신규(충돌 의심)] 지수: {}, 사유: {}", response.idxNm(), errorMsg);
+            results.add(saveSyncJobHistory(retryExisting.get(), JobType.INDEX_INFO, targetDate, workerIp, JobResult.FAILED, "신규 생성 중 예외 발생 (Unique 제약조건 충돌 의심): " + errorMsg));
+          } else {
+            log.error("[IndexInfo Sync 비정상 흐름] 워크플로우 위반 가능성 탐지 지수명: {} | 사유: {} | 조치: 해당 지수의 사전 등록 여부 및 마스터 데이터 확인 필요",
+                response.idxNm(), errorMsg);
+          }
         }
       } else {
         IndexInfo indexInfo = existing.get();

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -183,11 +183,13 @@ public class SyncJobService {
             indexInfo.getIndexName(), baseDateFrom, baseDateTo, actualTargetDate, indexDataList.size());
 
       } catch (Exception e) {
-        String errorLog = isSingleDay
-            ? e.getMessage()
-            : String.format("범위 연동 실패 (%s ~ %s): %s", baseDateFrom, baseDateTo, e.getMessage());
+        String safeErrorMsg = (e.getMessage() != null) ? e.getMessage() : e.getClass().getSimpleName();
 
-        log.error("[Sync 실패] 지수: {}, 사유: {}", indexInfo.getIndexName(), errorLog);
+        String errorLog = isSingleDay
+            ? String.format("[단건 연동 부분 실패] 개별 트랜잭션 격리 처리됨 | 사유: %s", safeErrorMsg)
+            : String.format("[범위 연동 부분 실패] 기간: %s ~ %s | 개별 트랜잭션 격리 처리됨 | 사유: %s", baseDateFrom, baseDateTo, safeErrorMsg);
+
+        log.error("[IndexData Sync 부분 실패] 지수: {} | {}", indexInfo.getIndexName(), errorLog);
 
         results.add(saveSyncJobHistory(indexInfo, JobType.INDEX_DATA, baseDateTo, workerIp, JobResult.FAILED, errorLog));
       }

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -106,7 +106,9 @@ public class SyncJobService {
           results.add(indexInfoSyncProcessor.createAndSaveHistory(toCreateRequest(response), targetDate, workerIp));
           log.info("[IndexInfo Sync 성공-신규] 지수: {}", response.idxNm());
         } catch (Exception e) {
-          log.error("[IndexInfo Sync 실패-신규] 지수: {}, 사유: {}", response.idxNm(), e.getMessage());
+          String errorMsg = (e.getMessage() != null) ? e.getMessage() : e.getClass().getSimpleName();
+          log.error("[IndexInfo Sync 비정상 흐름] 워크플로우 위반 가능성 탐지 지수명: {} | 사유: {} | 조치: 해당 지수의 사전 등록 여부 및 마스터 데이터 확인 필요",
+              response.idxNm(), errorMsg);
         }
       } else {
         IndexInfo indexInfo = existing.get();

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -191,7 +191,14 @@ public class SyncJobService {
 
         log.error("[IndexData Sync 부분 실패] 지수: {} | {}", indexInfo.getIndexName(), errorLog);
 
-        results.add(saveSyncJobHistory(indexInfo, JobType.INDEX_DATA, baseDateTo, workerIp, JobResult.FAILED, errorLog));
+        try {
+          results.add(saveSyncJobHistory(indexInfo, JobType.INDEX_DATA, baseDateTo, workerIp, JobResult.FAILED, errorLog));
+        } catch (Exception historyEx) {
+          String historyError = (historyEx.getMessage() != null)
+              ? historyEx.getMessage()
+              : historyEx.getClass().getSimpleName();
+          log.error("[IndexData Sync 실패 이력 저장 실패] 지수: {} | 사유: {}", indexInfo.getIndexName(), historyError);
+        }
       }
     }
     return results;

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -196,18 +196,15 @@ public class SyncJobService {
         String safeErrorMsg = (e.getMessage() != null) ? e.getMessage() : e.getClass().getSimpleName();
 
         String errorLog = isSingleDay
-            ? String.format("[단건 연동 부분 실패] 개별 트랜잭션 격리 처리됨 | 사유: %s", safeErrorMsg)
-            : String.format("[범위 연동 부분 실패] 기간: %s ~ %s | 개별 트랜잭션 격리 처리됨 | 사유: %s", baseDateFrom, baseDateTo, safeErrorMsg);
+            ? String.format("[단건 연동 실패] 해당 지수 외 정상 처리됨 | 사유: %s", safeErrorMsg)
+            : String.format("[범위 연동 실패] 기간: %s ~ %s | 타 데이터 영향 없음 | 사유: %s", baseDateFrom, baseDateTo, safeErrorMsg);
 
         log.error("[IndexData Sync 부분 실패] 지수: {} | {}", indexInfo.getIndexName(), errorLog);
 
         try {
           results.add(saveSyncJobHistory(indexInfo, JobType.INDEX_DATA, baseDateTo, workerIp, JobResult.FAILED, errorLog));
         } catch (Exception historyEx) {
-          String historyError = (historyEx.getMessage() != null)
-              ? historyEx.getMessage()
-              : historyEx.getClass().getSimpleName();
-          log.error("[IndexData Sync 실패 이력 저장 실패] 지수: {} | 사유: {}", indexInfo.getIndexName(), historyError);
+          log.error("[IndexData Sync 실패 이력 저장 실패] 지수: {} | 사유: {}", indexInfo.getIndexName(), historyEx.getMessage());
         }
       }
     }


### PR DESCRIPTION
## 관련 이슈

- Closes #95

## PR 유형

- [ ] feat: 새로운 기능
- [ ] fix: 버그 수정
- [x] refactor: 코드 리팩토링
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가·수정
- [ ] deploy: 배포 관련
- [ ] chore: 빌드·설정 변경

## 작업 내용

- syncIndexInfos() 예외 처리 로직 개선: 신규 지수 생성 실패 시 index_info_id NOT NULL 제약조건으로 인해 발생하는 시스템 에러(DataIntegrityViolation) 위험을 제거하고, '사전 등록 누락' 등 워크플로우 위반 가능성을 명시하는 상세 에러 로그로 대체했습니다.
- syncIndexData() 부분 실패 로깅 고도화: 다건 지수 연동 시 특정 지수에서 에러가 발생하더라도 전체 롤백되지 않도록 개별 트랜잭션 격리 구조를 유지하며, 에러 발생 시 SyncJob 이력에 '부분 실패' 및 '요청 기간'을 명시하여 장애 원인 추적을 용이하게 했습니다.
-

## 테스트 내용

- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 해당 없음

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 스크린샷 / 참고 자료

- 팀 코드 리뷰 문서 B-06, D-07

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 색인 생성 실패 시 오류 메시지를 더 안전하고 의미 있게 표시하도록 개선
  * 신규 생성 실패의 충돌 의심(이미 존재) 여부를 감지해 관련 오류 이력을 남기도록 처리
  * 단건·기간 동기화 실패 상황에 대해 각각 구분된 사용자용 오류 문구 제공
  * 동기화 실패 이력 저장 과정의 추가 오류가 원본 실패를 가리지 않도록 예외 처리를 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->