### PR TITLE
refactor: IndexDataQueryCondition 유효성 검증 로직 DTO 내부로 이동

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/dto/IndexDataQueryCondition.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/dto/IndexDataQueryCondition.java
@@ -1,60 +1,58 @@
 package com.sprint.mission.findex.domain.indexdata.dto;
 
+import ch.qos.logback.core.util.StringUtil;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
-import java.util.Set;
 import java.util.UUID;
 
 @Schema(description = "지수 데이터 목록 조회 조건")
 public record IndexDataQueryCondition(
 
-    @Schema(description = "지수 정보 ID", example = "9b19a600-16d4-41d1-9d36-6408a5feaad8")
+    @Schema(description = "지수 정보 ID")
     UUID indexInfoId,
 
-    @Schema(description = "시작 일자", example = "2024-01-01")
+    @Schema(description = "시작 일자")
     LocalDate startDate,
 
-    @Schema(description = "종료 일자", example = "2024-12-31")
+    @Schema(description = "종료 일자")
     LocalDate endDate,
 
     @Schema(description = "이전 페이지 마지막 요소 ID")
     UUID idAfter,
 
-    @Schema(description = "커서 (정렬 필드의 마지막 값)", example = "2024-01-02")
+    @Schema(description = "커서 (정렬 필드의 마지막 값)")
     String cursor,
 
-    @Schema(description = "정렬 필드 (baseDate, marketPrice, closingPrice, highPrice, lowPrice, versus, fluctuationRate, tradingQuantity, tradingPrice, marketTotalAmount)", example = "baseDate")
+    @Schema(description = "정렬 필드", allowableValues = {"baseDate", "marketPrice", "closingPrice",
+        "highPrice", "lowPrice", "versus", "fluctuationRate", "tradingQuantity", "tradingPrice",
+        "marketTotalAmount"}, defaultValue = "baseDate")
     String sortField,
 
-    @Schema(description = "정렬 방향 (asc, desc)", example = "desc")
+    @Schema(description = "정렬 방향", allowableValues = {"asc", "desc"}, defaultValue = "desc")
     String sortDirection,
 
-    @Schema(description = "페이지 크기 (1~100)", example = "10")
+    @Schema(description = "페이지 크기", defaultValue = "10")
     @Min(1) @Max(100)
     Integer size
 
 ) {
-
-  private static final Set<String> VALID_SORT_FIELDS =Set.of(
-      "baseDate", "marketPrice", "closingPrice", "highPrice", "lowPrice",
-      "versus", "fluctuationRate", "tradingQuantity", "tradingPrice", "marketTotalAmount"
-  );
-
   public IndexDataQueryCondition {
-    if (sortField == null) sortField = "baseDate";
-    if (sortDirection == null) sortDirection = "desc";
+    if (StringUtil.isNullOrEmpty(sortField)) sortField = "baseDate";
+    if (StringUtil.isNullOrEmpty(sortDirection)) sortDirection = "desc";
+    else sortDirection = sortDirection.toLowerCase();
     if (size == null) size = 10;
+  }
 
-    if (startDate != null && endDate != null && startDate.isAfter(endDate)){
-      throw new IllegalArgumentException("시작일은 종료일보다 미래일 수 없습니다.");
-    }
-    if ((cursor == null) != (idAfter == null)) {
-      throw new IllegalArgumentException("cursor와 idAfter는 함께 사용해야 합니다.");
-    }
-    if (!VALID_SORT_FIELDS.contains(sortField)) {
-      throw new IllegalArgumentException("지원하지 않는 정렬 필드입니다." + sortField);
-    }
+  @AssertTrue(message = "cursor와 idAfter는 함께 전달되어야 합니다")
+  public boolean isCursorAndIdAfterConsistent() {
+    return (cursor == null) == (idAfter == null);
+  }
+
+  @AssertTrue(message = "시작일은 종료일보다 미래일 수 없습니다")
+  public boolean isDateRangeValid() {
+    return startDate == null || endDate == null || !startDate.isAfter(endDate);
   }
 }

--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/dto/IndexDataQueryCondition.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/dto/IndexDataQueryCondition.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
+import java.util.Set;
 import java.util.UUID;
 
 @Schema(description = "지수 데이터 목록 조회 조건")
@@ -35,9 +36,25 @@ public record IndexDataQueryCondition(
     Integer size
 
 ) {
+
+  private static final Set<String> VALID_SORT_FIELDS =Set.of(
+      "baseDate", "marketPrice", "closingPrice", "highPrice", "lowPrice",
+      "versus", "fluctuationRate", "tradingQuantity", "tradingPrice", "marketTotalAmount"
+  );
+
   public IndexDataQueryCondition {
     if (sortField == null) sortField = "baseDate";
     if (sortDirection == null) sortDirection = "desc";
     if (size == null) size = 10;
+
+    if (startDate != null && endDate != null && startDate.isAfter(endDate)){
+      throw new IllegalArgumentException("시작일은 종료일보다 미래일 수 없습니다.");
+    }
+    if ((cursor == null) != (idAfter == null)) {
+      throw new IllegalArgumentException("cursor와 idAfter는 함께 사용해야 합니다.");
+    }
+    if (!VALID_SORT_FIELDS.contains(sortField)) {
+      throw new IllegalArgumentException("지원하지 않는 정렬 필드입니다." + sortField);
+    }
   }
 }

--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/service/IndexDataService.java
@@ -17,7 +17,6 @@ import com.sprint.mission.findex.global.exception.ApiException.ERROR;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -34,11 +33,6 @@ public class IndexDataService {
   private final IndexDataRepository indexDataRepository;
   private final IndexInfoRepository indexInfoRepository;
   private final IndexDataMapper indexDataMapper;
-
-  private static final Set<String> VALID_SORT_FIELDS = Set.of(
-      "baseDate", "marketPrice", "closingPrice", "highPrice", "lowPrice",
-      "versus", "fluctuationRate", "tradingQuantity", "tradingPrice", "marketTotalAmount"
-  );
 
   @Transactional
   public IndexDataResponse create(IndexDataCreateRequest request) {
@@ -101,17 +95,7 @@ public class IndexDataService {
 
   @Transactional(readOnly = true)
   public CursorPageResponse<IndexDataResponse> getList(IndexDataQueryCondition request) {
-    if (request.startDate() != null && request.endDate() != null
-        && request.startDate().isAfter(request.endDate())) {
-      throw new ApiException(ERROR.COMMON_INVALID_REQUEST);
-    }
-    if ((request.cursor() == null) != (request.idAfter() == null)) {
-      throw new ApiException(ERROR.COMMON_INVALID_REQUEST);
-    }
-    String sortField = request.sortField() != null ? request.sortField() : "baseDate";
-    if (!VALID_SORT_FIELDS.contains(sortField)) {
-      throw new ApiException(ERROR.COMMON_INVALID_REQUEST);
-    }
+
     return indexDataRepository.findAll(request);
   }
 


### PR DESCRIPTION
## 관련 이슈

- Closes #96 

## PR 유형

- [x] refactor: 코드 리팩토링

## 작업 내용

- `IndexDataQueryCondition` compact constructor에 유효성 검증 로직 추가
  - startDate > endDate 날짜 역전 체크
  - cursor와 idAfter 동시 존재 여부 체크
  - sortField 유효성 체크
- `IndexDataService.getList()`에서 검증 코드 제거
- `IndexDataService`의 `VALID_SORT_FIELDS` 상수 제거

## 테스트 내용

- [x] 해당 없음

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- Service에서 DTO로 검증 로직 이동이 적절한지 확인 부탁드립니다.
- IndexDataQueryCondition compact constructor에서 IllegalArgumentException을 던지는 방식이 적절한지 피드백 부탁드립니다.

## 스크린샷 / 참고 자료

- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 정렬 및 페이지 기본값과 빈값 처리 방식이 정리되어 요청 처리가 일관되게 동작합니다.
  * API 설명(메타데이터)이 더 명확해져 정렬 필드/방향과 페이지 크기 기본값이 문서화되었습니다.

* **Bug Fixes**
  * 커서/후속 ID 쌍의 일관성 검사와 시작/종료일 범위 검증이 추가되어 잘못된 요청을 방지합니다.
  * 정렬 필드 허용값 처리 방식 변경으로 이전과 다른 동작이 발생할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->