### PR TITLE
fix: 빌드 에러 수정을 위한 Swagger 어노테이션 임포트 추가

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/controller/api/SyncJobApi.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/controller/api/SyncJobApi.java
@@ -5,6 +5,7 @@ import com.sprint.mission.findex.domain.syncjob.dto.SyncJobQueryCondition;
 import com.sprint.mission.findex.domain.syncjob.dto.SyncJobResponse;
 import com.sprint.mission.findex.global.common.dto.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;


### PR DESCRIPTION
## 관련 이슈

- Closes #103 

## PR 유형

- [x] fix: 버그 수정
- [x] deploy: 배포 관련

## 작업 내용

- SyncJobApi 클래스 내 누락된 Swagger @Parameter 임포트 추가
- 빌드 시 발생하던 컴파일 에러(cannot find symbol: class Parameter) 해결

## 테스트 내용

- [x] 로컬 테스트 완료 (./gradlew compileJava 통과 확인)

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- Railway 빌드 로그에서 확인된 Swagger 어노테이션 참조 오류를 수정했습니다.
- 추가적인 임포트 누락이 있는지 빌드 로그를 통해 재확인했습니다.

## 스크린샷 / 참고 자료

- 에러 위치: /app/src/main/java/com/sprint/mission/findex/domain/syncjob/controller/api/SyncJobApi.java:24
