### PR TITLE
fix: 입력 type 오류 에러 핸들링

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/controller/api/SyncJobApi.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/controller/api/SyncJobApi.java
@@ -5,6 +5,7 @@ import com.sprint.mission.findex.domain.syncjob.dto.SyncJobQueryCondition;
 import com.sprint.mission.findex.domain.syncjob.dto.SyncJobResponse;
 import com.sprint.mission.findex.global.common.dto.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;

--- a/src/main/java/com/sprint/mission/findex/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprint/mission/findex/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.findex.global.exception;
 
-import static com.sprint.mission.findex.global.exception.ApiException.ERROR.*;
+import static com.sprint.mission.findex.global.exception.ApiException.ERROR.COMMON_INVALID_REQUEST;
+import static com.sprint.mission.findex.global.exception.ApiException.ERROR.COMMON_UNEXPECTED_ERROR;
 
 import com.sprint.mission.findex.global.exception.ApiException.ERROR;
 import java.util.stream.Collectors;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -17,7 +19,8 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(ApiException.class)
   public ResponseEntity<ErrorResponse> handleApiException(ApiException e) {
     ERROR error = e.getError();
-    log.warn("[ApiException] {} status: {}, code: {}, message: {}", error.name(), error.getHttpStatus().value(), error.getCode(), error.getMessage());
+    log.warn("[ApiException] {} status: {}, code: {}, message: {}", error.name(),
+        error.getHttpStatus().value(), error.getCode(), error.getMessage());
     return ResponseEntity
         .status(error.getHttpStatus())
         .body(ErrorResponse.of(
@@ -34,7 +37,27 @@ public class GlobalExceptionHandler {
     String details = e.getBindingResult().getFieldErrors().stream()
         .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
         .collect(Collectors.joining(", "));
-    log.warn("[ApiException] {} status: {}, code: {}, message: {} | {}", error.name(), error.getHttpStatus().value(), error.getCode(), error.getMessage(), details);
+    log.warn("[ApiException] {} status: {}, code: {}, message: {} | {}", error.name(),
+        error.getHttpStatus().value(), error.getCode(), error.getMessage(), details);
+    return ResponseEntity
+        .status(error.getHttpStatus())
+        .body(ErrorResponse.of(
+            error.getHttpStatus().value(),
+            error.getMessage(),
+            error.getCode() + " | " + details
+        ));
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleTypeMismatchException(
+      MethodArgumentTypeMismatchException e) {
+    ERROR error = COMMON_INVALID_REQUEST;
+    String details = String.format("%s: %s 타입이어야 합니다",
+        e.getName(),
+        e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown"
+    );
+    log.warn("[ApiException] {} status: {}, code: {}, message: {} | {}", error.name(),
+        error.getHttpStatus().value(), error.getCode(), error.getMessage(), details);
     return ResponseEntity
         .status(error.getHttpStatus())
         .body(ErrorResponse.of(
@@ -47,7 +70,8 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleException(Exception e) {
     ERROR error = COMMON_UNEXPECTED_ERROR;
-    log.error("[UnexpectedException] ", e);
+    log.error("[UnexpectedException] cause: {}, message: {}", e.getClass().getSimpleName(),
+        e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
     return ResponseEntity
         .status(error.getHttpStatus())
         .body(ErrorResponse.of(

--- a/src/main/java/com/sprint/mission/findex/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprint/mission/findex/global/exception/GlobalExceptionHandler.java
@@ -71,7 +71,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ErrorResponse> handleException(Exception e) {
     ERROR error = COMMON_UNEXPECTED_ERROR;
     log.error("[UnexpectedException] cause: {}, message: {}", e.getClass().getSimpleName(),
-        e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+        e.getCause() != null ? e.getCause().getMessage() : e.getMessage(), e);
     return ResponseEntity
         .status(error.getHttpStatus())
         .body(ErrorResponse.of(


### PR DESCRIPTION
## 관련 이슈

- Closes #107

## PR 유형

- [x] fix: 버그 수정

## 작업 내용

**GlobalExceptionHandler**
- `MethodArgumentTypeMismatchException` 핸들러 추가 — 잘못된 타입 입력 시 500 → 400 반환
  - 메시지 형식: `{필드명}: {타입} 타입이어야 합니다`
- `Exception` 핸들러 NPE 방어: `e.getCause()` null 체크 추가

**application.yml**
- `com.sprint.mission.findex`: DEBUG → INFO (운영 환경 로그 최적화)
- `ExceptionHandlerExceptionResolver`: 미설정 → ERROR
  - `GlobalExceptionHandler`에서 이미 직접 로그를 남기고 있어, Spring 내부에서 WARN으로 중복 출력되는 로그 억제

## 테스트 내용

- [x] UUID 파라미터 위치에 non-UUID 값 전달 시 400 반환 확인
- [x] 응답 body `code` 필드에 `COMMON_001 | {필드명}: {타입} 타입이어야 합니다` 포함 확인
- [x] 운영 로그에서 `ExceptionHandlerExceptionResolver` WARN 중복 미출력 확인

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- `ExceptionHandlerExceptionResolver` 로그 레벨 ERROR 설정이 운영 환경에서 의도한 대로 동작하는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API 오류 응답 처리 개선으로 사용자에게 더 명확한 오류 정보 제공
  * 요청 매개변수 타입 불일치 시 상세한 검증 메시지 제공
  * 필드 유효성 검사 실패 때 구체적인 오류 정보 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->