### PR TITLE
fix: 지수 정보 요약 목록 정렬 기준 추가

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/querydsl/impl/IndexInfoCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/querydsl/impl/IndexInfoCustomRepositoryImpl.java
@@ -37,6 +37,7 @@ public class IndexInfoCustomRepositoryImpl implements IndexInfoCustomRepository 
             indexInfo.indexName
         ))
         .from(indexInfo)
+        .orderBy(indexInfo.indexName.asc(), indexInfo.id.asc())
         .fetch();
   }
 


### PR DESCRIPTION
## 관련 이슈

- Closes #108

## PR 유형

- [x] fix: 버그 수정

## 작업 내용

- `findIndexInfoSummaries()` 쿼리에 `orderBy` 누락으로 배포 환경(PostgreSQL)에서 정렬 순서 미보장 문제 수정
- 지수 이름(`indexName`) 오름차순, 동일 시 `id` 오름차순으로 정렬 기준 추가

## 테스트 내용

- [x] 해당 없음

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- 정렬 기준(지수 이름 오름차순)이 요구사항에 맞는지 확인 부탁드립니다.

## 스크린샷 / 참고 자료

- H2(로컬)에서는 삽입 순서로 반환되어 재현되지 않으나, PostgreSQL(배포)에서는 ORDER BY 없이 순서가 보장되지 않음.