### PR TITLE
fix: 수동 동기화 후 데이터 중복 저장 방지

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -22,6 +22,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -153,23 +154,29 @@ public class SyncJobService {
 
         LocalDate actualTargetDate = baseDateTo;
 
-        Set<LocalDate> existingDates = indexDataRepository
+        Set<LocalDate> seenDates = indexDataRepository
             .findByIndexInfoIdAndBaseDateBetween(indexInfo.getId(), baseDateFrom, baseDateTo)
             .stream()
             .map(IndexData::getBaseDate)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(HashSet::new));
 
-        List<IndexData> indexDataList = indexDataMapper.toEntityList(externalDataList, indexInfo)
-            .stream()
-            .filter(d -> !existingDates.contains(d.getBaseDate()))
-            .collect(Collectors.toList());
-
-        if (!indexDataList.isEmpty()) {
-          actualTargetDate = indexDataList.stream()
-              .map(IndexData::getBaseDate)
-              .max(LocalDate::compareTo)
-              .orElse(baseDateTo);
+        List<IndexData> indexDataList = new ArrayList<>();
+        for (IndexData d : indexDataMapper.toEntityList(externalDataList, indexInfo)) {
+          if (seenDates.add(d.getBaseDate())) {
+            indexDataList.add(d);
+          }
         }
+
+        if (indexDataList.isEmpty()) {
+          log.info("[Sync 스킵] 지수: {}, 요청범위: {} ~ {} -> 모든 날짜 이미 존재",
+              indexInfo.getIndexName(), baseDateFrom, baseDateTo);
+          continue;
+        }
+
+        actualTargetDate = indexDataList.stream()
+            .map(IndexData::getBaseDate)
+            .max(LocalDate::compareTo)
+            .orElse(baseDateTo);
 
         String logMessage = isSingleDay
             ? null


### PR DESCRIPTION
## 관련 이슈                

  - Closes #102                                                                        
   
  ## PR 유형                                                                           
                  
  - [x] fix: 버그 수정                                                               

  ## 작업 내용

  - `externalDataList` 내부에 같은 날짜가 중복으로 포함될 경우 `existingDates` 필터를
  통과해 duplicate INSERT가 발생하는 문제 수정
  - `seenDates.add()` 패턴으로 DB 기존 데이터 중복 및 API 응답 내부 중복(페이지 경계
  겹침 등) 모두 제거
  - `indexDataList`가 비어있을 때(모든 날짜 이미 존재) `saveIndexDataAndHistory` 호출을
   건너뛰어 0건 SUCCESS SyncJob이 불필요하게 기록되는 문제 수정

  ## 테스트 내용

  - [x] 로컬 테스트 완료
  - [x] API 테스트 완료

  ## 체크리스트

  - [x] 셀프 리뷰를 완료했습니다.
  - [x] 코드 컨벤션을 지켰습니다.
  - [x] API 변경 사항이 Swagger에 반영되어 있습니다.
  - [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
  - [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
  - [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

  ## 리뷰 포인트

  - `seenDates.add()` 패턴이 `SyncBatchService`와 동일하게 맞춰졌는지 확인
  부탁드립니다.
  - `indexDataList` 비어있을 때 `continue`로 스킵하는 방식이 적절한지 검토
  부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 데이터 동기화 시 중복 데이터 처리 로직 개선
  * 빈 동기화 데이터에 대한 불필요한 처리 제거

* **Chores**
  * 내부 데이터 처리 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->