### PR TITLE
fix: 즐겨찾기 성과 조회 2N+1 쿼리 구조 개선

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardPerformanceService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardPerformanceService.java
@@ -13,8 +13,17 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 @Service
 @RequiredArgsConstructor
@@ -27,34 +36,37 @@ public class DashboardPerformanceService {
     public List<IndexPerformanceResponse> getFavoriteIndexPerformance(
             IndexPerformancePeriodType periodType
     ) {
-        return indexInfoRepository.findAllByFavoriteTrue().stream()
-                .map(indexInfo -> toIndexPerformance(indexInfo, periodType))
+        List<IndexInfo> favoriteIndexInfos = indexInfoRepository.findAllByFavoriteTrue();
+        if (favoriteIndexInfos.isEmpty()) {
+            return List.of();
+        }
+
+        List<UUID> indexInfoIds = favoriteIndexInfos.stream()
+                .map(IndexInfo::getId)
+                .toList();
+
+        Map<UUID, IndexData> currentDataByIndexId = indexDataRepository.findLatestByIndexInfoIds(indexInfoIds)
+                .stream()
+                .collect(toMap(indexData -> indexData.getIndexInfo().getId(), identity()));
+
+        Map<UUID, IndexData> beforeDataByIndexId = getBeforeDataByIndexId(currentDataByIndexId, periodType);
+
+        return favoriteIndexInfos.stream()
+                .map(indexInfo -> toIndexPerformance(
+                        indexInfo,
+                        currentDataByIndexId.get(indexInfo.getId()),
+                        beforeDataByIndexId.get(indexInfo.getId())
+                ))
                 .filter(Objects::nonNull)
                 .toList();
     }
 
     private IndexPerformanceResponse toIndexPerformance(
         IndexInfo indexInfo,
-        IndexPerformancePeriodType periodType
+        IndexData currentData,
+        IndexData beforeData
     ) {
-        IndexData currentData = indexDataRepository
-                .findFirstByIndexInfoIdOrderByBaseDateDesc(indexInfo.getId())
-                .orElse(null);
-
-        if (currentData == null) {
-            return null;
-        }
-
-        LocalDate targetDate = getTargetDate(currentData.getBaseDate(), periodType);
-
-        IndexData beforeData = indexDataRepository
-                .findFirstByIndexInfoIdAndBaseDateLessThanEqualOrderByBaseDateDesc(
-                        indexInfo.getId(),
-                        targetDate
-                )
-                .orElse(null);
-
-        if (beforeData == null) {
+        if (currentData == null || beforeData == null) {
             return null;
         }
 
@@ -72,6 +84,27 @@ public class DashboardPerformanceService {
                 currentPrice,
                 beforePrice
         );
+    }
+
+    private Map<UUID, IndexData> getBeforeDataByIndexId(
+            Map<UUID, IndexData> currentDataByIndexId,
+            IndexPerformancePeriodType periodType
+    ) {
+        Map<LocalDate, List<UUID>> indexIdsByTargetDate = currentDataByIndexId.values().stream()
+                .collect(groupingBy(
+                        indexData -> getTargetDate(indexData.getBaseDate(), periodType),
+                        mapping(indexData -> indexData.getIndexInfo().getId(), toList())
+                ));
+
+        Map<UUID, IndexData> beforeDataByIndexId = new HashMap<>();
+        indexIdsByTargetDate.forEach((targetDate, indexInfoIds) ->
+                indexDataRepository.findLatestByIndexInfoIdsAndBaseDateLessThanEqual(indexInfoIds, targetDate)
+                        .forEach(indexData ->
+                                beforeDataByIndexId.put(indexData.getIndexInfo().getId(), indexData)
+                        )
+        );
+
+        return beforeDataByIndexId;
     }
 
     private LocalDate getTargetDate(LocalDate currentDate, IndexPerformancePeriodType periodType) {

--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/repository/IndexDataRepository.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/repository/IndexDataRepository.java
@@ -34,6 +34,38 @@ public interface IndexDataRepository extends JpaRepository<IndexData, UUID>,
       LocalDate baseDate
   );
 
+  @Query("""
+      select d
+      from IndexData d
+      join fetch d.indexInfo i
+      where i.id in :indexInfoIds
+        and d.baseDate = (
+            select max(d2.baseDate)
+            from IndexData d2
+            where d2.indexInfo.id = i.id
+        )
+      """)
+  List<IndexData> findLatestByIndexInfoIds(
+      @Param("indexInfoIds") List<UUID> indexInfoIds
+  );
+
+  @Query("""
+      select d
+      from IndexData d
+      join fetch d.indexInfo i
+      where i.id in :indexInfoIds
+        and d.baseDate = (
+            select max(d2.baseDate)
+            from IndexData d2
+            where d2.indexInfo.id = i.id
+              and d2.baseDate <= :targetDate
+        )
+      """)
+  List<IndexData> findLatestByIndexInfoIdsAndBaseDateLessThanEqual(
+      @Param("indexInfoIds") List<UUID> indexInfoIds,
+      @Param("targetDate") LocalDate targetDate
+  );
+
   @Query("SELECT d FROM IndexData d JOIN FETCH d.indexInfo WHERE " +
       "(:indexInfoId IS NULL OR d.indexInfo.id = :indexInfoId) AND " +
       "(:startDate IS NULL OR d.baseDate >= :startDate) AND " +


### PR DESCRIPTION
## 관련 이슈

- Closes #98 

## PR 유형

- [x] feat: 새로운 기능
- [ ] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가·수정
- [ ] deploy: 배포 관련
- [ ] chore: 빌드·설정 변경

## 작업 내용

- 즐겨찾기 성과 조회 시 지수별 개별 조회(`1 + 2N`)가 발생하던 구조를 배치 조회 기반으로 개선했습니다.
- `IndexDataRepository`에 `IN절 + JOIN FETCH` 기반 배치 조회 메서드(`findLatestByIndexInfoIds`, `findLatestByIndexInfoIdsAndBaseDateLessThanEqual`)를 추가했습니다.
- `DashboardPerformanceService`에서 favorite 지수 ID를 먼저 수집한 뒤, 최신값은 한 번에 조회하고, 기준값은 targetDate 기준 그룹핑 후 일괄 조회하도록 변경했습니다.

## 테스트 내용

- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 해당 없음

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- 기존 `1 + 2N` 구조를 `favorite 조회 1회 + 최신값 배치 조회 1회 + 기준값 targetDate 그룹별 조회` 구조로 줄인 부분을 중점적으로 봐주시면 감사하겠습니다.

## 스크린샷 / 참고 자료

- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 대시보드 인덱스 성능 조회 로직을 데이터베이스 배치 쿼리 처리로 최적화하여 조회 성능 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->