### PR TITLE
refactor: cursor 없는 첫 페이지 요청에서만 count 쿼리 실행

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
@@ -67,8 +67,9 @@ public class AutoSyncConfigService {
       nextCursor = extractCursor(last, effectiveSortField);
     }
 
-    long totalElements = autoSyncConfigRepository.countWithFilter(
-        condition.indexInfoId(), condition.enabled());
+    Long totalElements = (condition.cursor() == null)
+        ? autoSyncConfigRepository.countWithFilter(condition.indexInfoId(), condition.enabled())
+        : null;
 
     return CursorPageResponse.of(
         content,

--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/repository/querydsl/impl/IndexDataCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/repository/querydsl/impl/IndexDataCustomRepositoryImpl.java
@@ -72,15 +72,17 @@ public class IndexDataCustomRepositoryImpl implements IndexDataCustomRepository 
     String nextCursor = hasNext ? extractCursor(sortField, result.get(result.size() - 1)) : null;
     UUID nextIdAfter = hasNext ? result.get(result.size() - 1).id() : null;
 
-    Long totalElements = queryFactory
-        .select(indexData.count())
-        .from(indexData)
-        .where(
-            eqIndexInfoId(request.indexInfoId()),
-            goeStartDate(request.startDate()),
-            loeEndDate(request.endDate())
-        )
-        .fetchOne();
+    Long totalElements = (request.cursor() == null)
+        ? queryFactory
+            .select(indexData.count())
+            .from(indexData)
+            .where(
+                eqIndexInfoId(request.indexInfoId()),
+                goeStartDate(request.startDate()),
+                loeEndDate(request.endDate())
+            )
+            .fetchOne()
+        : null;
 
     return CursorPageResponse.of(result, nextCursor, nextIdAfter, size, totalElements, hasNext);
   }

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/querydsl/impl/IndexInfoCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/repository/querydsl/impl/IndexInfoCustomRepositoryImpl.java
@@ -69,8 +69,8 @@ public class IndexInfoCustomRepositoryImpl implements IndexInfoCustomRepository 
         .limit(condition.size() + 1)
         .fetch();
 
-    long totalElements = Optional.ofNullable(
-        queryFactory
+    Long totalElements = (condition.cursor() == null)
+        ? queryFactory
             .select(indexInfo.count())
             .from(indexInfo)
             .where(
@@ -79,7 +79,7 @@ public class IndexInfoCustomRepositoryImpl implements IndexInfoCustomRepository 
                 eqFavorite(condition.favorite())
             )
             .fetchOne()
-    ).orElse(0L);
+        : null;
 
     boolean hasNext = content.size() > condition.size();
     String nextCursor = null;

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/repository/querydsl/impl/SyncJobCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/repository/querydsl/impl/SyncJobCustomRepositoryImpl.java
@@ -58,20 +58,22 @@ public class SyncJobCustomRepositoryImpl implements SyncJobCustomRepository {
         .limit(size + 1L)
         .fetch();
 
-    Long totalElements = queryFactory
-        .select(syncJob.count())
-        .from(syncJob)
-        .where(
-            eqJobType(condition.jobType()),
-            eqIndexInfoId(condition.indexInfoId()),
-            eqStatus(condition.status()),
-            goeBaseDateFrom(condition.baseDateFrom()),
-            loeBaseDateTo(condition.baseDateTo()),
-            containsWorker(condition.worker()),
-            goeJobTimeFrom(condition.jobTimeFrom()),
-            loeJobTimeTo(condition.jobTimeTo())
-        )
-        .fetchOne();
+    Long totalElements = (cursor == null)
+        ? queryFactory
+            .select(syncJob.count())
+            .from(syncJob)
+            .where(
+                eqJobType(condition.jobType()),
+                eqIndexInfoId(condition.indexInfoId()),
+                eqStatus(condition.status()),
+                goeBaseDateFrom(condition.baseDateFrom()),
+                loeBaseDateTo(condition.baseDateTo()),
+                containsWorker(condition.worker()),
+                goeJobTimeFrom(condition.jobTimeFrom()),
+                loeJobTimeTo(condition.jobTimeTo())
+            )
+            .fetchOne()
+        : null;
 
     boolean hasNext = syncJobs.size() > size;
 


### PR DESCRIPTION
## 관련 이슈

- Closes #111

## PR 유형

- [x] refactor: 코드 리팩토링

## 작업 내용

- `cursor`가 `null`인 첫 페이지 요청에서만 `totalElements` count 쿼리 실행
- `cursor`가 존재하는 이후 페이지 요청에서는 count 쿼리 생략 → `totalElements: null` 반환
- 적용 범위: `IndexInfoCustomRepositoryImpl`, `IndexDataCustomRepositoryImpl`, `SyncJobCustomRepositoryImpl`, `AutoSyncConfigService`
- `AutoSyncConfigRepository.countWithFilter()` 반환 타입 `long` → `Long` 변경

## 테스트 내용

- [x] 로컬 테스트 완료
- [x] 해당 없음 (테스트 코드 작성 불필요)

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- count 쿼리 생략 조건: `cursor == null` 여부만 확인. 첫 페이지가 아닌 경우 `totalElements`는 `null`로 반환되며, 클라이언트는 초기 로드 시 받은 값을 재사용하는 방식.