### PR TITLE
fix: CSV Export 음수 값 작은따옴표 제거 및 DeleteMapping 경로 슬래시 추가

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/controller/IndexDataController.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/controller/IndexDataController.java
@@ -46,7 +46,7 @@ public class IndexDataController implements IndexDataApi {
     return ResponseEntity.ok(indexDataService.update(id, request));
   }
 
-  @DeleteMapping("{id}")
+  @DeleteMapping("/{id}")
   public ResponseEntity<Void> delete(@PathVariable UUID id) {
     indexDataService.delete(id);
     return ResponseEntity.noContent().build();


### PR DESCRIPTION
## 관련 이슈

- Closes #129 

## PR 유형

- [x] fix: 버그 수정


## 작업 내용

- `IndexDataService.csvCell()` 메서드에서 수식 인젝션 방어 문자 `=+-@` → `=+@` 변경
- `-`로 시작하는 음수 값에 불필요한 작은따옴표가 붙지 않도록 수정
- `@DeleteMapping("{id}")` → `@DeleteMapping("/{id}")` 경로 슬래시 추가

## 테스트 내용

- [x] 로컬 테스트 완료
- [x] API 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- `csvCell()`에서 `-` 제거 시 수식 인젝션 방어에 문제가 없는지 확인 부탁드립니다.

## 스크린샷 / 참고 자료

- 수정전
<img width="999" height="447" alt="image" src="https://github.com/user-attachments/assets/874a8bd9-4287-434b-9e54-48d17a0f8378" />

- 수정후
<img width="999" height="429" alt="image" src="https://github.com/user-attachments/assets/093b5796-0e7d-4d23-a597-226284a06114" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인덱스 데이터 삭제 API 엔드포인트의 경로 형식을 수정하여 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->