### PR TITLE
refactor: IndexInfoService.createByOpenAPI 반환 타입 IndexInfoResponse로 통일

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/service/IndexInfoService.java
@@ -40,8 +40,8 @@ public class IndexInfoService {
   }
 
   @Transactional
-  public IndexInfoResponse createByOpenAPI(IndexInfoCreateRequest req) {
-    return mapper.toResponse(create(req, SourceType.OPEN_API));
+  public IndexInfo createByOpenAPI(IndexInfoCreateRequest req) {
+    return create(req, SourceType.OPEN_API);
   }
 
   @Transactional

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/service/IndexInfoService.java
@@ -40,8 +40,8 @@ public class IndexInfoService {
   }
 
   @Transactional
-  public IndexInfo createByOpenAPI(IndexInfoCreateRequest req) {
-    return create(req, SourceType.OPEN_API);
+  public IndexInfoResponse createByOpenAPI(IndexInfoCreateRequest req) {
+    return mapper.toResponse(create(req, SourceType.OPEN_API));
   }
 
   @Transactional

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexInfoSyncProcessor.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexInfoSyncProcessor.java
@@ -1,13 +1,9 @@
 package com.sprint.mission.findex.domain.syncjob.service;
 
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
-import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoResponse;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
 import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
-import com.sprint.mission.findex.domain.indexinfo.repository.IndexInfoRepository;
 import com.sprint.mission.findex.domain.indexinfo.service.IndexInfoService;
-import com.sprint.mission.findex.global.exception.ApiException;
-import com.sprint.mission.findex.global.exception.ApiException.ERROR;
 import com.sprint.mission.findex.domain.syncjob.dto.SyncJobResponse;
 import com.sprint.mission.findex.domain.syncjob.entity.JobResult;
 import com.sprint.mission.findex.domain.syncjob.entity.JobType;
@@ -24,15 +20,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class IndexInfoSyncProcessor {
 
     private final IndexInfoService indexInfoService;
-    private final IndexInfoRepository indexInfoRepository;
     private final SyncJobRepository syncJobRepository;
     private final SyncJobMapper syncJobMapper;
 
     @Transactional
     public SyncJobResponse createAndSaveHistory(IndexInfoCreateRequest createRequest, LocalDate targetDate, String workerIp) {
-        IndexInfoResponse created = indexInfoService.createByOpenAPI(createRequest);
-        IndexInfo indexInfo = indexInfoRepository.findById(created.id())
-            .orElseThrow(() -> new ApiException(ERROR.INDEX_INFO_NOT_FOUND));
+        IndexInfo indexInfo = indexInfoService.createByOpenAPI(createRequest);
         return saveHistory(indexInfo, targetDate, workerIp, JobResult.SUCCESS, null);
     }
 

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexInfoSyncProcessor.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexInfoSyncProcessor.java
@@ -1,9 +1,13 @@
 package com.sprint.mission.findex.domain.syncjob.service;
 
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
+import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoResponse;
 import com.sprint.mission.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
 import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
+import com.sprint.mission.findex.domain.indexinfo.repository.IndexInfoRepository;
 import com.sprint.mission.findex.domain.indexinfo.service.IndexInfoService;
+import com.sprint.mission.findex.global.exception.ApiException;
+import com.sprint.mission.findex.global.exception.ApiException.ERROR;
 import com.sprint.mission.findex.domain.syncjob.dto.SyncJobResponse;
 import com.sprint.mission.findex.domain.syncjob.entity.JobResult;
 import com.sprint.mission.findex.domain.syncjob.entity.JobType;
@@ -19,12 +23,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class IndexInfoSyncProcessor {
 
     private final IndexInfoService indexInfoService;
+    private final IndexInfoRepository indexInfoRepository;
     private final SyncJobRepository syncJobRepository;
 
     @Transactional
     public SyncJobResponse createAndSaveHistory(IndexInfoCreateRequest createRequest, LocalDate targetDate, String workerIp) {
-        IndexInfo created = indexInfoService.createByOpenAPI(createRequest);
-        return saveHistory(created, targetDate, workerIp, JobResult.SUCCESS, null);
+        IndexInfoResponse created = indexInfoService.createByOpenAPI(createRequest);
+        IndexInfo indexInfo = indexInfoRepository.findById(created.id())
+            .orElseThrow(() -> new ApiException(ERROR.INDEX_INFO_NOT_FOUND));
+        return saveHistory(indexInfo, targetDate, workerIp, JobResult.SUCCESS, null);
     }
 
     @Transactional

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexInfoSyncProcessor.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/IndexInfoSyncProcessor.java
@@ -11,8 +11,9 @@ import com.sprint.mission.findex.global.exception.ApiException.ERROR;
 import com.sprint.mission.findex.domain.syncjob.dto.SyncJobResponse;
 import com.sprint.mission.findex.domain.syncjob.entity.JobResult;
 import com.sprint.mission.findex.domain.syncjob.entity.JobType;
-import com.sprint.mission.findex.domain.syncjob.entity.SyncJob;
+import com.sprint.mission.findex.domain.syncjob.mapper.SyncJobMapper;
 import com.sprint.mission.findex.domain.syncjob.repository.SyncJobRepository;
+
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -25,6 +26,7 @@ public class IndexInfoSyncProcessor {
     private final IndexInfoService indexInfoService;
     private final IndexInfoRepository indexInfoRepository;
     private final SyncJobRepository syncJobRepository;
+    private final SyncJobMapper syncJobMapper;
 
     @Transactional
     public SyncJobResponse createAndSaveHistory(IndexInfoCreateRequest createRequest, LocalDate targetDate, String workerIp) {
@@ -41,14 +43,8 @@ public class IndexInfoSyncProcessor {
     }
 
     private SyncJobResponse saveHistory(IndexInfo indexInfo, LocalDate targetDate, String workerIp, JobResult result, String errorMessage) {
-        SyncJob syncJob = SyncJob.builder()
-            .indexInfo(indexInfo)
-            .jobType(JobType.INDEX_INFO)
-            .targetDate(targetDate)
-            .worker(workerIp)
-            .result(result)
-            .errorMessage(errorMessage)
-            .build();
-        return SyncJobResponse.from(syncJobRepository.save(syncJob));
+        return syncJobMapper.toResponse(syncJobRepository.save(
+            syncJobMapper.toEntity(indexInfo, JobType.INDEX_INFO, targetDate, workerIp, result, errorMessage)
+        ));
     }
 }


### PR DESCRIPTION
 ## 관련 이슈                                                                                         
                                                                                                       
  - Closes #128                                                                                        
                                                                                                       
  ## PR 유형                                                                                           
                                                                                                       
  - [ ] feat: 새로운 기능                                                                              
  - [ ] fix: 버그 수정                                                                                 
  - [x] refactor: 코드 리팩토링
  - [ ] docs: 문서 수정
  - [ ] test: 테스트 추가·수정
  - [ ] deploy: 배포 관련
  - [ ] chore: 빌드·설정 변경

  ## 작업 내용

  - `IndexInfoService.createByOpenAPI` 반환 타입 `IndexInfo` → `IndexInfoResponse`로 변경
  - `IndexInfoSyncProcessor`에 `IndexInfoRepository` 주입 추가
  - `createAndSaveHistory`에서 `createByOpenAPI` 결과 id로 entity 별도 조회

  ## 테스트 내용

  - [ ] 테스트 코드 작성
  - [x] 로컬 테스트 완료
  - [ ] API 테스트 완료
  - [ ] 해당 없음

  ## 체크리스트

  - [x] 셀프 리뷰를 완료했습니다.
  - [x] 코드 컨벤션을 지켰습니다.
  - [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
  - [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
  - [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
  - [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

  ## 리뷰 포인트

  - `createByOpenAPI` 반환 타입 변경으로 인해 `IndexInfoSyncProcessor`에서 DB 조회가 1회 추가됩니다.
  허용 가능한 비용인지 확인 부탁드립니다.

  ## 스크린샷 / 참고 자료

  - 해당 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 동기화 작업 생성 로직의 내부 구조를 개선하여 코드 유지보수성을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->