### PR TITLE
refactor: toIndexPerformance null 반환을 Optional로 명시

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardPerformanceService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardPerformanceService.java
@@ -16,7 +16,7 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.function.Function.identity;
@@ -57,17 +57,17 @@ public class DashboardPerformanceService {
                         currentDataByIndexId.get(indexInfo.getId()),
                         beforeDataByIndexId.get(indexInfo.getId())
                 ))
-                .filter(Objects::nonNull)
+                .flatMap(Optional::stream)
                 .toList();
     }
 
-    private IndexPerformanceResponse toIndexPerformance(
+    private Optional<IndexPerformanceResponse> toIndexPerformance(
         IndexInfo indexInfo,
         IndexData currentData,
         IndexData beforeData
     ) {
         if (currentData == null || beforeData == null) {
-            return null;
+            return Optional.empty();
         }
 
         BigDecimal currentPrice = currentData.getClosingPrice();
@@ -75,7 +75,7 @@ public class DashboardPerformanceService {
         BigDecimal versus = currentPrice.subtract(beforePrice);
         BigDecimal fluctuationRate = calculateFluctuationRate(currentPrice, beforePrice);
 
-        return new IndexPerformanceResponse(
+        return Optional.of(new IndexPerformanceResponse(
                 indexInfo.getId(),
                 indexInfo.getIndexClassification(),
                 indexInfo.getIndexName(),
@@ -83,7 +83,7 @@ public class DashboardPerformanceService {
                 fluctuationRate,
                 currentPrice,
                 beforePrice
-        );
+        ));
     }
 
     private Map<UUID, IndexData> getBeforeDataByIndexId(


### PR DESCRIPTION
## 관련 이슈

- Closes #134 

## PR 유형

- [ ] feat: 새로운 기능
- [ ] fix: 버그 수정
- [x] refactor: 코드 리팩토링
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가·수정
- [ ] deploy: 배포 관련
- [ ] chore: 빌드·설정 변경

## 작업 내용

- `DashboardPerformanceService#toIndexPerformance()`의 반환 타입을 `Optional<IndexPerformanceResponse>`로 변경했습니다.
- `null` 반환 대신 `Optional.empty()` / `Optional.of(...)`를 사용하도록 수정했습니다.
- 호출부에서 `filter(Objects::nonNull)` 대신 `flatMap(Optional::stream)`을 사용하도록 변경했습니다.

## 테스트 내용

- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 해당 없음

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- `toIndexPerformance()`가 값이 없을 수 있다는 사실을 메서드 시그니처에 드러내도록 변경했습니다.
- 호출부가 더 이상 암묵적으로 null 처리에 의존하지 않고, Optional 기반으로 명시적으로 동작하도록 수정했습니다.
- 기능 변경은 없고, null 반환 계약을 더 안전하고 읽기 쉬운 구조로 드러내는 리팩토링입니다.

## 스크린샷 / 참고 자료

- 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* 대시보드 성능 조회의 내부 안정성 개선

---

**참고:** 이번 릴리스는 사용자에게 직접 보이는 기능 변화가 없습니다. 시스템 안정성을 위한 내부 개선사항입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->