### PR TITLE
fix: 지수 데이터 수집 시 타 분류 데이터가 혼입되는 오류 수정

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/mapper/IndexDataMapper.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/mapper/IndexDataMapper.java
@@ -5,6 +5,7 @@ import com.sprint.mission.findex.domain.indexdata.entity.IndexData;
 import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
 import com.sprint.mission.findex.domain.syncclient.dto.IndexDataApiResponse;
 import java.util.List;
+import java.util.Objects;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -32,7 +33,7 @@ public interface IndexDataMapper {
   default List<IndexData> toEntityList(List<IndexDataApiResponse> dtoList, IndexInfo indexInfo) {
     if (dtoList == null) return null;
     return dtoList.stream()
-        .filter(res -> res.idxCsf().equals(indexInfo.getIndexClassification()))
+        .filter(res -> Objects.equals(res.idxCsf(), indexInfo.getIndexClassification()))
         .map(dto -> toEntity(dto, indexInfo))
         .toList();
   }

--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/mapper/IndexDataMapper.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/mapper/IndexDataMapper.java
@@ -32,6 +32,7 @@ public interface IndexDataMapper {
   default List<IndexData> toEntityList(List<IndexDataApiResponse> dtoList, IndexInfo indexInfo) {
     if (dtoList == null) return null;
     return dtoList.stream()
+        .filter(res -> res.idxCsf().equals(indexInfo.getIndexClassification()))
         .map(dto -> toEntity(dto, indexInfo))
         .toList();
   }


### PR DESCRIPTION
## 관련 이슈

- Closes #137

## PR 유형

- [x] fix: 버그 수정

## 작업 내용

- **데이터 정합성 필터링 도입 (Mapper)**:
  - 외부 OpenAPI 응답 시 요청한 지수 분류와 다른 데이터가 혼입되는 문제 발견.
  - `MapStruct`의 `default` 메서드 내 `filter` 로직을 추가하여 `indexClassification`이 일치하는 데이터만 수집하도록 수정.

## 테스트 내용

- [x] 로컬 테스트 완료 (PostgreSQL 환경 검증)
- **데이터 필터링 검증**: 
  - 특정 날짜(예: 03/26)에 중복으로 유입되던 불일치 데이터(3699.89 vs 818.99)가 필터링 후 정상 데이터만 남는 것을 확인.

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- **필터링 로직**: `IndexMapper`에서 `indexClassification`을 비교하여 데이터를 거르는 방식이 적절한지 검토 부탁드립니다.

## 스크린샷 / 참고 자료

### [수정 전 임시 로그 - 데이터 혼입 발생]
- 동일 날짜에 분류가 다른 데이터가 중복 기입되어 값이 튀는 현상 확인
```text
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260326, 종가: 3699.89
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260326, 종가: 818.99
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260325, 종가: 3819.39
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260325, 종가: 865.1
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260324, 종가: 3731.53
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260324, 종가: 845.96
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260323, 종가: 827.89  (이상 데이터 혼입 시점)
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260323, 종가: 3723.03
```

### [수정 후 임시 로그 - 필터링 적용]
- 수집 단계에서 분류 불일치 데이터를 차단하여 정합성 확보
```text
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260326, 종가: 3699.89
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260325, 종가: 3819.39
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260324, 종가: 3731.53
지수 분류: KOSPI시리즈, 지수 이름: 기계·장비, 연동 날짜: 20260323, 종가: 3723.03
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 색인 데이터 변환 과정에서 분류 기준이 일치하는 항목만 결과에 포함되도록 필터링 로직을 수정했습니다. 이로써 조회된 색인 목록에 올바르지 않은 분류의 항목이 포함되는 문제가 해결되어, 사용자에게 보다 정확한 분류별 데이터가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->