### PR TITLE
fix: 전체 지수 연동 시 indexfolds -1 처리 불가 오류 수정

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/dto/IndexDataSyncRequest.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/dto/IndexDataSyncRequest.java
@@ -1,10 +1,13 @@
 package com.sprint.mission.findex.domain.syncjob.dto;
 
+import com.sprint.mission.findex.global.exception.ApiException;
+import com.sprint.mission.findex.global.exception.ApiException.ERROR;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 @Schema(name = "IndexDataSyncRequest", description = "지수 데이터 연동 요청")
 public record IndexDataSyncRequest(
@@ -22,8 +25,27 @@ public record IndexDataSyncRequest(
     LocalDate baseDateTo
 ) {
   public IndexDataSyncRequest {
+    boolean hasAllSentinel = indexInfoIds != null && indexInfoIds.stream().anyMatch("-1"::equals);
+
+    if (hasAllSentinel && indexInfoIds.size() != 1) {
+      throw new ApiException(ERROR.COMMON_INVALID_REQUEST);
+    }
+
+    if (!hasAllSentinel && indexInfoIds != null) {
+      for (String id : indexInfoIds) {
+        if (id == null || id.isBlank()) {
+          throw new ApiException(ERROR.COMMON_INVALID_REQUEST);
+        }
+        try {
+          UUID.fromString(id);
+        } catch (IllegalArgumentException e) {
+          throw new ApiException(ERROR.COMMON_INVALID_REQUEST);
+        }
+      }
+    }
+
     if (baseDateFrom != null && baseDateTo != null && baseDateFrom.isAfter(baseDateTo)) {
-      throw new IllegalArgumentException("시작일은 종료일보다 미래일 수 없습니다.");
+      throw new ApiException(ERROR.COMMON_INVALID_REQUEST);
     }
   }
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/dto/IndexDataSyncRequest.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/dto/IndexDataSyncRequest.java
@@ -5,14 +5,13 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.UUID;
 
 @Schema(name = "IndexDataSyncRequest", description = "지수 데이터 연동 요청")
 public record IndexDataSyncRequest(
 
-    @Schema(description = "지수 정보 ID 목록")
+    @Schema(description = "지수 정보 ID 목록 (-1은 전체 지수 연동)")
     @NotEmpty(message = "최소 하나 이상의 지수 정보 ID가 필요합니다.")
-    List<UUID> indexInfoIds,
+    List<String> indexInfoIds,
 
     @Schema(description = "대상 날짜(부터)")
     @NotNull(message = "시작일(baseDateFrom)은 필수입니다.")

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -134,7 +134,7 @@ public class SyncJobService {
     }
     return results;
   }
-  public List<SyncJobResponse> syncIndexData(List<UUID> indexInfoIds, LocalDate baseDateFrom, LocalDate baseDateTo, String workerIp) {
+  public List<SyncJobResponse> syncIndexData(List<String> indexInfoIds, LocalDate baseDateFrom, LocalDate baseDateTo, String workerIp) {
 
     if (baseDateFrom.isAfter(baseDateTo)) {
       throw new ApiException(ApiException.ERROR.COMMON_INVALID_REQUEST);
@@ -143,7 +143,14 @@ public class SyncJobService {
     boolean isSingleDay = baseDateFrom.isEqual(baseDateTo);
     List<SyncJobResponse> results = new ArrayList<>();
 
-    for (UUID indexInfoId : indexInfoIds) {
+    List<UUID> resolvedIds;
+    if (indexInfoIds.size() == 1 && "-1".equals(indexInfoIds.get(0))) {
+      resolvedIds = indexInfoRepository.findAll().stream().map(IndexInfo::getId).toList();
+    } else {
+      resolvedIds = indexInfoIds.stream().map(UUID::fromString).toList();
+    }
+
+    for (UUID indexInfoId : resolvedIds) {
 
       IndexInfo indexInfo = indexInfoRepository.findById(indexInfoId).orElse(null);
       if (indexInfo == null) {


### PR DESCRIPTION
## 관련 이슈                                                                  
                                                                                
  - Closes #140                                                                 
                                                                                
  ## PR 유형                              
                                                                                
  - [x] fix: 버그 수정     
  

  ## 작업 내용

  - `IndexDataSyncRequest`의 `indexInfoIds` 타입을 `List<UUID>`에서
  `List<String>`으로 변경
  - `SyncJobService.syncIndexData`에서 `-1` 수신 시 전체 IndexInfo 조회 후
  연동하도록 분기 처리

  ## 테스트 내용

  - [ ] 테스트 코드 작성
  - [x] 로컬 테스트 완료
  - [x] API 테스트 완료
  - [ ] 해당 없음

  ## 체크리스트

  - [x] 셀프 리뷰를 완료했습니다.
  - [x] 코드 컨벤션을 지켰습니다.
  - [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
  - [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
  - [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
  - [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

  ## 리뷰 포인트

  - 프런트엔드가 "전체 지수" 선택 시 `indexInfoIds: [-1]`을 전송하는 컨벤션을   
  백엔드에서 수용하는 방식이 적절한지 검토 부탁드립니다.                        
  - `-1` 감지 및 전체 조회 로직을 DTO 메서드가 아닌 서비스 레이어에             
  위치시켰습니다. DTO 메서드 방식은 `IndexDataSyncRequest`와 `SyncJobService` 두
   곳을 모두 수정해야 하고, DTO에서 null을 반환하는 어색한 구조가 생깁니다.     
  서비스 레이어에서 처리하면 수정 범위가 서비스 한 곳으로 한정되고, 비즈니스    
  로직과 데이터 전달 역할이 명확히 분리됩니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인덱스 동기화 요청에 모든 인덱스를 지정하는 `-1` 옵션 추가

* **개선 사항**
  * 인덱스 식별자 입력 형식이 더 유연해져 문자열 입력을 지원
  * 요청 입력 검증이 강화되어 잘못된 식별자 입력을 명확히 차단

* **버그 수정**
  * 날짜 범위 오류 처리 방식이 일관된 사용자용 오류 응답으로 통합
<!-- end of auto-generated comment: release notes by coderabbit.ai -->