### PR TITLE
feat: 지수 정보 연동 시 지수 데이터 함께 저장

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -238,6 +238,11 @@ public class SyncJobService {
 
   private void trySaveIndexData(IndexDataApiResponse response, IndexInfo indexInfo, LocalDate targetDate, String workerIp) {
     try {
+      LocalDate responseDate = LocalDate.parse(response.basDt(), DateTimeFormatter.BASIC_ISO_DATE);
+      if (!responseDate.isEqual(targetDate)) {
+        log.warn("[IndexData Sync 스킵] 지수: {}, 날짜 불일치: 요청={}, 응답={}", indexInfo.getIndexName(), targetDate, responseDate);
+        return;
+      }
       if (!indexDataRepository.existsByIndexInfoAndBaseDate(indexInfo, targetDate)) {
         IndexData indexData = indexDataMapper.toEntity(response, indexInfo);
         indexDataSyncProcessor.saveIndexDataAndHistory(List.of(indexData), indexInfo, targetDate, workerIp, null);

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -106,6 +106,9 @@ public class SyncJobService {
         try {
           results.add(indexInfoSyncProcessor.createAndSaveHistory(toCreateRequest(response), targetDate, workerIp));
           log.info("[IndexInfo Sync 성공-신규] 지수: {}", response.idxNm());
+          final LocalDate finalTargetDate = targetDate;
+          indexInfoRepository.findByIndexClassificationAndIndexName(response.idxCsf(), response.idxNm())
+              .ifPresent(indexInfo -> trySaveIndexData(response, indexInfo, finalTargetDate, workerIp));
         } catch (Exception e) {
           String errorMsg = (e.getMessage() != null) ? e.getMessage() : e.getClass().getSimpleName();
 
@@ -126,6 +129,7 @@ public class SyncJobService {
         try {
           results.add(indexInfoSyncProcessor.updateAndSaveHistory(indexInfo, toUpdateRequest(response), targetDate, workerIp));
           log.info("[IndexInfo Sync 성공-갱신] 지수: {}", response.idxNm());
+          trySaveIndexData(response, indexInfo, targetDate, workerIp);
         } catch (Exception e) {
           log.error("[IndexInfo Sync 실패-갱신] 지수: {}, 사유: {}", response.idxNm(), e.getMessage());
           results.add(saveSyncJobHistory(indexInfo, JobType.INDEX_INFO, targetDate, workerIp, JobResult.FAILED, e.getMessage()));
@@ -230,6 +234,17 @@ public class SyncJobService {
     return syncJobRepository.searchSyncJobPage(
         condition, condition.cursor(), condition.idAfter(),
         condition.sortField(), condition.sortDirection(), condition.size());
+  }
+
+  private void trySaveIndexData(IndexDataApiResponse response, IndexInfo indexInfo, LocalDate targetDate, String workerIp) {
+    try {
+      if (!indexDataRepository.existsByIndexInfoAndBaseDate(indexInfo, targetDate)) {
+        IndexData indexData = indexDataMapper.toEntity(response, indexInfo);
+        indexDataSyncProcessor.saveIndexDataAndHistory(List.of(indexData), indexInfo, targetDate, workerIp, null);
+      }
+    } catch (Exception e) {
+      log.warn("[IndexData Sync 스킵] 지수: {}, 날짜: {}, 사유: {}", indexInfo.getIndexName(), targetDate, e.getMessage());
+    }
   }
 
   private IndexInfoCreateRequest toCreateRequest(IndexDataApiResponse response) {

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -243,7 +243,8 @@ public class SyncJobService {
         indexDataSyncProcessor.saveIndexDataAndHistory(List.of(indexData), indexInfo, targetDate, workerIp, null);
       }
     } catch (Exception e) {
-      log.warn("[IndexData Sync 스킵] 지수: {}, 날짜: {}, 사유: {}", indexInfo.getIndexName(), targetDate, e.getMessage());
+      String errorMsg = (e.getMessage() != null) ? e.getMessage() : e.getClass().getSimpleName();
+      log.warn("[IndexData Sync 실패] 지수: {}, 날짜: {}, 사유: {}", indexInfo.getIndexName(), targetDate, errorMsg);
     }
   }
 


### PR DESCRIPTION
## 관련 이슈                                                                                           
                                                                                                         
  - Closes #149                                                                                          
                                                                                                         
  ## PR 유형                                                                                             
                                                                                                         
  - [x] feat: 새로운 기능                                                                                
  - [ ] fix: 버그 수정                                                                                   
  - [ ] refactor: 코드 리팩토링
  - [ ] docs: 문서 수정
  - [ ] test: 테스트 추가·수정
  - [ ] deploy: 배포 관련
  - [ ] chore: 빌드·설정 변경

  ## 작업 내용

  - `SyncJobService.syncIndexInfos()`에 `trySaveIndexData()` 헬퍼 메서드 추가
  - 지수 정보 연동 성공 시 동일 KRX API 응답 데이터로 지수 데이터(IndexData)도 함께 저장
  - `existsByIndexInfoAndBaseDate`로 중복 저장 사전 차단
  - IndexData 저장 실패가 IndexInfo 연동 결과에 영향을 주지 않도록 별도 try-catch로 격리

  ## 테스트 내용

  - [ ] 테스트 코드 작성
  - [x] 로컬 테스트 완료
  - [x] API 테스트 완료
  - [ ] 해당 없음

  ## 체크리스트

  - [x] 셀프 리뷰를 완료했습니다.
  - [x] 코드 컨벤션을 지켰습니다.
  - [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
  - [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
  - [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
  - [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

  ## 리뷰 포인트

  - 신규 IndexInfo 생성 시 IndexInfo 엔티티를 얻기 위해 `findByIndexClassificationAndIndexName` 조회가
  1회 추가됩니다. 구조 변경 없이 최소 변경으로 해결하기 위해 선택한 방식으로, 성능 영향이 우려된다면 검토
   부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정 및 개선**
  * 인덱스 데이터 저장 시 요청한 기준일과 응답일이 일치하는 경우에만 저장하도록 조건이 추가되어 중복·잘못된 저장이 방지됩니다.
  * 이미 존재하는 인덱스 데이터는 재저장하지 않도록 검증이 강화되었습니다.
  * 인덱스 데이터 저장 중 발생한 오류는 경고로 처리되어 전체 동기화 흐름이 중단되지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->