### PR TITLE
feat: 연동 작업자 IP 마스킹 처리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/controller/SyncJobController.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/controller/SyncJobController.java
@@ -35,7 +35,7 @@ public class SyncJobController implements SyncJobApi {
       @RequestParam(required = false) LocalDate targetDate,
       HttpServletRequest servletRequest) {
 
-    String workerIp = servletRequest.getRemoteAddr();
+    String workerIp = maskIp(servletRequest.getRemoteAddr());
     List<SyncJobResponse> results = syncJobService.syncIndexInfos(targetDate, workerIp);
     return ResponseEntity.status(HttpStatus.ACCEPTED).body(results);
   }
@@ -46,7 +46,7 @@ public class SyncJobController implements SyncJobApi {
       @Valid @RequestBody IndexDataSyncRequest request,
       HttpServletRequest servletRequest) {
 
-    String workerIp = servletRequest.getRemoteAddr();
+    String workerIp = maskIp(servletRequest.getRemoteAddr());
     List<SyncJobResponse> results = syncJobService.syncIndexData(
         request.indexInfoIds(),
         request.baseDateFrom(),
@@ -62,5 +62,10 @@ public class SyncJobController implements SyncJobApi {
       @Valid @ParameterObject @ModelAttribute SyncJobQueryCondition condition) {
 
     return ResponseEntity.ok(syncJobService.getSyncJobHistory(condition));
+  }
+
+  private String maskIp(String ip) {
+    if (ip == null) return "unknown";
+    return "xxx.xxx.xxx.xxx";
   }
 }

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/controller/SyncJobController.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/controller/SyncJobController.java
@@ -66,6 +66,17 @@ public class SyncJobController implements SyncJobApi {
 
   private String maskIp(String ip) {
     if (ip == null) return "unknown";
-    return "xxx.xxx.xxx.xxx";
+    if (ip.contains(":")) {
+      String[] parts = ip.split(":", -1);
+      if (parts.length >= 2) {
+        return parts[0] + ":" + parts[1] + ":*:*:*:*:*:*";
+      }
+      return "*:*:*:*:*:*:*:*";
+    }
+    String[] parts = ip.split("\\.", -1);
+    if (parts.length == 4) {
+      return parts[0] + "." + parts[1] + ".*.*";
+    }
+    return "*.*.*.*";
   }
 }


### PR DESCRIPTION
 ## 관련 이슈                                                                    
                                                                                  
  - Closes #151                                                                   
                                                                                  
  ## PR 유형                                                                      
                  
  - [x] feat: 새로운 기능

  ## 작업 내용

  - `SyncJobController`에 `maskIp()` 메서드 추가
  - 지수 정보 연동, 지수 데이터 연동 두 엔드포인트에 IP 마스킹 적용
  - IPv4/IPv6 구분 없이 `192.168.xxx.xxx`로 통일 처리

  ## 테스트 내용

  - [x] 로컬 테스트 완료

  ## 체크리스트

  - [x] 셀프 리뷰를 완료했습니다.
  - [x] 코드 컨벤션을 지켰습니다.
  - [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
  - [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
  - [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
  - [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

  ## 리뷰 포인트

  - 마스킹 로직을 컨트롤러 한 곳에서만 처리하여 중복 없이 두 엔드포인트에 적용했습니다.
  

  ## 스크린샷 / 참고 자료
  
<img width="1344" height="903" alt="image" src="https://github.com/user-attachments/assets/c41a2ec6-c553-4891-9ce5-21e50917272d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 애플리케이션에 캐싱 메커니즘이 도입되어 전반적인 성능 및 응답 속도가 향상되었습니다.
  * 동기화 작업에서 클라이언트 IP가 자동으로 마스킹되어 사용자 프라이버시와 보안이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->