### PR TITLE
fix: CSV Export 음수 값 작은따옴표 제거, 인코딩 수정 및 방어선 추가

### DIFF
--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/service/IndexDataService.java
@@ -25,6 +25,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -103,21 +106,33 @@ public class IndexDataService {
   public void exportCsv(IndexDataExportRequest request, HttpServletResponse response)
       throws IOException {
 
-    response.setContentType("text/csv; charset=UTF-8");
-    response.setCharacterEncoding("UTF-8");
-    String filename = "index-data-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")) + ".csv";
-    response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
-    PrintWriter writer = response.getWriter();
-    writer.print('\uFEFF');
-
-    writer.println("기준일자,지수분류,지수명,시가,종가,고가,저가,전일대비,등락률,거래량,거래대금,시가총액");
-
+    List<IndexData> dataList;
     try (Stream<IndexData> stream = indexDataRepository.streamForExport(
         request.indexInfoId(),
         request.startDate(),
         request.endDate()
     )) {
-      stream.forEach(data -> writer.println(String.join(",",
+      dataList = stream.toList();
+    }
+
+    if (dataList.isEmpty()) {
+      throw new ApiException(ERROR.INDEX_DATA_NOT_FOUND);
+    }
+
+    response.setContentType("text/csv; charset=UTF-8");
+    response.setCharacterEncoding("UTF-8");
+    String filename = "index-data-" + LocalDateTime.now()
+        .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")) + ".csv";
+    response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
+
+    PrintWriter writer = new PrintWriter(
+        new OutputStreamWriter(response.getOutputStream(), StandardCharsets.UTF_8)
+    );
+    writer.print('\uFEFF');
+    writer.println("기준일자,지수분류,지수명,시가,종가,고가,저가,전일대비,등락률,거래량,거래대금,시가총액");
+
+    try {
+      dataList.forEach(data -> writer.println(String.join(",",
           csvCell(data.getBaseDate().toString()),
           csvCell(data.getIndexInfo().getIndexClassification()),
           csvCell(data.getIndexInfo().getIndexName()),
@@ -131,14 +146,16 @@ public class IndexDataService {
           csvCell(data.getTradingPrice().toString()),
           csvCell(data.getMarketTotalAmount().toString())
       )));
+    } catch (Exception e) {
+      throw new ApiException(ERROR.INDEX_DATA_CSV_EXPORT_FAILED);
+    } finally {
+      writer.flush();
     }
-    writer.flush();
   }
-
   private static String csvCell(String raw) {
     if (raw == null) return "";
     String safe = raw;
-    if (!safe.isEmpty() && "=+-@".indexOf(safe.charAt(0)) >= 0) {
+    if (!safe.isEmpty() && "=+@".indexOf(safe.charAt(0)) >= 0) {
       safe = "'" + safe;
     }
     if (safe.contains("\"")) {

--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/service/IndexDataService.java
@@ -27,7 +27,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.Iterator;
 
 @Service
 @RequiredArgsConstructor
@@ -106,50 +106,51 @@ public class IndexDataService {
   public void exportCsv(IndexDataExportRequest request, HttpServletResponse response)
       throws IOException {
 
-    List<IndexData> dataList;
     try (Stream<IndexData> stream = indexDataRepository.streamForExport(
         request.indexInfoId(),
         request.startDate(),
         request.endDate()
     )) {
-      dataList = stream.toList();
-    }
+      Iterator<IndexData> iterator = stream.iterator();
 
-    if (dataList.isEmpty()) {
-      throw new ApiException(ERROR.INDEX_DATA_NOT_FOUND);
-    }
+      // 데이터 없으면 response 설정 전에 예외 던지기
+      if (!iterator.hasNext()) {
+        throw new ApiException(ERROR.INDEX_DATA_NOT_FOUND);
+      }
 
-    response.setContentType("text/csv; charset=UTF-8");
-    response.setCharacterEncoding("UTF-8");
-    String filename = "index-data-" + LocalDateTime.now()
-        .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")) + ".csv";
-    response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
+      // 데이터 있을 때만 response 설정
+      response.setContentType("text/csv; charset=UTF-8");
+      response.setCharacterEncoding("UTF-8");
+      String filename = "index-data-" + LocalDateTime.now()
+          .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")) + ".csv";
+      response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
 
-    PrintWriter writer = new PrintWriter(
-        new OutputStreamWriter(response.getOutputStream(), StandardCharsets.UTF_8)
-    );
-    writer.print('\uFEFF');
-    writer.println("기준일자,지수분류,지수명,시가,종가,고가,저가,전일대비,등락률,거래량,거래대금,시가총액");
+      PrintWriter writer = new PrintWriter(
+          new OutputStreamWriter(response.getOutputStream(), StandardCharsets.UTF_8)
+      );
+      writer.print('\uFEFF');
+      writer.println("기준일자,지수분류,지수명,시가,종가,고가,저가,전일대비,등락률,거래량,거래대금,시가총액");
 
-    try {
-      dataList.forEach(data -> writer.println(String.join(",",
-          csvCell(data.getBaseDate().toString()),
-          csvCell(data.getIndexInfo().getIndexClassification()),
-          csvCell(data.getIndexInfo().getIndexName()),
-          csvCell(data.getMarketPrice().toString()),
-          csvCell(data.getClosingPrice().toString()),
-          csvCell(data.getHighPrice().toString()),
-          csvCell(data.getLowPrice().toString()),
-          csvCell(data.getVersus().toString()),
-          csvCell(data.getFluctuationRate().toString()),
-          csvCell(data.getTradingQuantity().toString()),
-          csvCell(data.getTradingPrice().toString()),
-          csvCell(data.getMarketTotalAmount().toString())
-      )));
-    } catch (Exception e) {
-      throw new ApiException(ERROR.INDEX_DATA_CSV_EXPORT_FAILED);
-    } finally {
-      writer.flush();
+      try {
+        iterator.forEachRemaining(data -> writer.println(String.join(",",
+            csvCell(data.getBaseDate().toString()),
+            csvCell(data.getIndexInfo().getIndexClassification()),
+            csvCell(data.getIndexInfo().getIndexName()),
+            csvCell(data.getMarketPrice().toString()),
+            csvCell(data.getClosingPrice().toString()),
+            csvCell(data.getHighPrice().toString()),
+            csvCell(data.getLowPrice().toString()),
+            csvCell(data.getVersus().toString()),
+            csvCell(data.getFluctuationRate().toString()),
+            csvCell(data.getTradingQuantity().toString()),
+            csvCell(data.getTradingPrice().toString()),
+            csvCell(data.getMarketTotalAmount().toString())
+        )));
+      } catch (Exception e) {
+        throw new ApiException(ERROR.INDEX_DATA_CSV_EXPORT_FAILED);
+      } finally {
+        writer.flush();
+      }
     }
   }
   private static String csvCell(String raw) {

--- a/src/main/java/com/sprint/mission/findex/global/exception/ApiException.java
+++ b/src/main/java/com/sprint/mission/findex/global/exception/ApiException.java
@@ -16,6 +16,7 @@ public class ApiException extends RuntimeException {
     // IndexData
     INDEX_DATA_NOT_FOUND("INDEX_DATA_001", "지수 데이터를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INDEX_DATA_DUPLICATED("INDEX_DATA_002", "이미 존재하는 지수 데이터입니다.", HttpStatus.CONFLICT),
+    INDEX_DATA_CSV_EXPORT_FAILED("INDEX_DATA_003", "CSV Export에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // SyncJob
     SYNC_JOB_NOT_FOUND("SYNC_001", "연동 작업을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
@@ -28,6 +29,8 @@ public class ApiException extends RuntimeException {
     // Common
     COMMON_INVALID_REQUEST("COMMON_001", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
     COMMON_UNEXPECTED_ERROR("COMMON_002", "예기치 않은 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+
 
     private final String code;
     private final String message;


### PR DESCRIPTION
## 관련 이슈

- Closes #153  

## PR 유형

- [x] fix: 버그 수정


## 작업 내용

- `csvCell()` 메서드에서 수식 인젝션 방어 문자 `=+-@` → `=+@` 변경
  - `-`로 시작하는 음수 값에 불필요한 작은따옴표 제거
- `PrintWriter`를 `OutputStreamWriter(StandardCharsets.UTF_8)` 기반으로 변경
  - Excel에서 한글 인코딩 깨짐 수정
- CSV Export 방어선 추가
  - Iterator 방식으로 Stream 유지하면서 데이터 없을 때 선제 체크
  - 데이터 없을 시 404 에러 반환 (response 설정 전 처리)
  - Export 실패 시 500 에러 반환
- `ApiException.ERROR`에 `INDEX_DATA_CSV_EXPORT_FAILED` 에러 코드 추가

## 테스트 내용

- [x] 로컬 테스트 완료
- [x] API 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- Iterator 방식으로 Stream을 유지하면서 첫 데이터 존재 여부를 먼저 확인하는 방식이 적절한지 확인 부탁드립니다.
- `INDEX_DATA_CSV_EXPORT_FAILED` 에러 코드 추가가 컨벤션에 맞는지 확인 부탁드립니다.

## 스크린샷 / 참고 자료

- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * CSV 내보내기 실패 시 명확한 오류 메시지 제공
  * 빈 데이터 내보내기 시도 시 적절한 오류 처리

* **개선 사항**
  * CSV 내보내기 과정 중 예외 발생 시 처리 강화
  * 데이터 인코딩 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->