### PR TITLE
feat: 대시보드 API Caffeine 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,11 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.springframework.boot:spring-boot-starter-cache'
-    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     implementation "com.querydsl:querydsl-jpa:5.1.0:jakarta"

--- a/src/main/java/com/sprint/mission/findex/domain/autosyncconfig/batch/SyncScheduler.java
+++ b/src/main/java/com/sprint/mission/findex/domain/autosyncconfig/batch/SyncScheduler.java
@@ -5,14 +5,16 @@ import com.sprint.mission.findex.domain.autosyncconfig.service.SyncBatchService;
 import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
 import com.sprint.mission.findex.domain.syncclient.client.KrxOpenApiClient;
 import com.sprint.mission.findex.domain.syncclient.dto.IndexDataApiResponse;
+import jakarta.annotation.PostConstruct;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -28,6 +30,7 @@ public class SyncScheduler {
 
   private final KrxOpenApiClient krxOpenApiClient;
   private final SyncBatchService syncBatchService;
+  private final CacheManager cacheManager;
 
   @PostConstruct
   public void validateDefaultSyncDays() {
@@ -59,6 +62,17 @@ public class SyncScheduler {
     }
 
     log.info("자동 연동 배치 완료");
+    evictIndexDataCaches();
+  }
+
+  private void evictIndexDataCaches() {
+    List.of("indexChart", "performanceRank", "favoritePerformance")
+        .forEach(name -> {
+          Cache cache = cacheManager.getCache(name);
+          if (cache != null) {
+            cache.clear();
+          }
+        });
   }
 
   private void syncForIndexInfo(IndexInfo indexInfo, LocalDate to) {

--- a/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardChartService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardChartService.java
@@ -17,17 +17,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
 public class DashboardChartService {
 
   private final IndexInfoRepository indexInfoRepository;
   private final IndexDataRepository indexDataRepository;
 
+  @Cacheable(cacheNames = "indexChart", key = "#id + '_' + #periodType")
   public IndexChartResponse getIndexChart(
       UUID id,
       IndexChartPeriodType periodType

--- a/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardPerformanceService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardPerformanceService.java
@@ -33,6 +33,7 @@ public class DashboardPerformanceService {
     private final IndexInfoRepository indexInfoRepository;
     private final IndexDataRepository indexDataRepository;
 
+    @Cacheable(cacheNames = "favoritePerformance", key = "#periodType")
     public List<IndexPerformanceResponse> getFavoriteIndexPerformance(
             IndexPerformancePeriodType periodType
     ) {

--- a/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardPerformanceService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardPerformanceService.java
@@ -1,15 +1,17 @@
 package com.sprint.mission.findex.domain.dashboard.service;
 
-import com.sprint.mission.findex.domain.dashboard.dto.IndexPerformanceResponse;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
 import com.sprint.mission.findex.domain.dashboard.dto.IndexPerformancePeriodType;
+import com.sprint.mission.findex.domain.dashboard.dto.IndexPerformanceResponse;
 import com.sprint.mission.findex.domain.indexdata.entity.IndexData;
 import com.sprint.mission.findex.domain.indexdata.repository.IndexDataRepository;
 import com.sprint.mission.findex.domain.indexinfo.entity.IndexInfo;
 import com.sprint.mission.findex.domain.indexinfo.repository.IndexInfoRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
@@ -18,12 +20,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardService.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/dashboard/service/DashboardService.java
@@ -28,6 +28,7 @@ public class DashboardService {
 
   private final IndexDataRepository indexDataRepository;
 
+  @Cacheable(cacheNames = "performanceRank", key = "#condition.periodType + '_' + #condition.limit + '_' + #condition.indexInfoId")
   public List<RankedIndexPerformanceResponse> getIndexPerformanceRank(
       RankedIndexPerformanceQueryCondition condition) {
 

--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/service/IndexDataService.java
@@ -16,18 +16,20 @@ import com.sprint.mission.findex.global.exception.ApiException;
 import com.sprint.mission.findex.global.exception.ApiException.ERROR;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Iterator;
 import java.util.UUID;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +39,10 @@ public class IndexDataService {
   private final IndexInfoRepository indexInfoRepository;
   private final IndexDataMapper indexDataMapper;
 
+  @Caching(evict = {
+      @CacheEvict(cacheNames = "indexChart", allEntries = true),
+      @CacheEvict(cacheNames = "favoritePerformance", allEntries = true)
+  })
   @Transactional
   public IndexDataResponse create(IndexDataCreateRequest request) {
     IndexInfo indexInfo = indexInfoRepository.findById(request.indexInfoId())
@@ -68,6 +74,10 @@ public class IndexDataService {
     }
   }
 
+  @Caching(evict = {
+      @CacheEvict(cacheNames = "indexChart", allEntries = true),
+      @CacheEvict(cacheNames = "favoritePerformance", allEntries = true)
+  })
   @Transactional
   public IndexDataResponse update(UUID id, IndexDataUpdateRequest request) {
     IndexData indexData = indexDataRepository.findById(id)
@@ -88,6 +98,10 @@ public class IndexDataService {
     return indexDataMapper.toResponse(indexData);
   }
 
+  @Caching(evict = {
+      @CacheEvict(cacheNames = "indexChart", allEntries = true),
+      @CacheEvict(cacheNames = "favoritePerformance", allEntries = true)
+  })
   @Transactional
   public void delete(UUID id) {
     IndexData indexData = indexDataRepository.findById(id)

--- a/src/main/java/com/sprint/mission/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexdata/service/IndexDataService.java
@@ -40,9 +40,10 @@ public class IndexDataService {
   private final IndexDataMapper indexDataMapper;
 
   @Caching(evict = {
+      @CacheEvict(cacheNames = "favoritePerformance", allEntries = true),
       @CacheEvict(cacheNames = "indexChart", allEntries = true),
-      @CacheEvict(cacheNames = "favoritePerformance", allEntries = true)
-  })
+      @CacheEvict(cacheNames = "performanceRank", allEntries = true)
+})
   @Transactional
   public IndexDataResponse create(IndexDataCreateRequest request) {
     IndexInfo indexInfo = indexInfoRepository.findById(request.indexInfoId())
@@ -75,8 +76,9 @@ public class IndexDataService {
   }
 
   @Caching(evict = {
+      @CacheEvict(cacheNames = "favoritePerformance", allEntries = true),
       @CacheEvict(cacheNames = "indexChart", allEntries = true),
-      @CacheEvict(cacheNames = "favoritePerformance", allEntries = true)
+      @CacheEvict(cacheNames = "performanceRank", allEntries = true)
   })
   @Transactional
   public IndexDataResponse update(UUID id, IndexDataUpdateRequest request) {
@@ -99,8 +101,9 @@ public class IndexDataService {
   }
 
   @Caching(evict = {
+      @CacheEvict(cacheNames = "favoritePerformance", allEntries = true),
       @CacheEvict(cacheNames = "indexChart", allEntries = true),
-      @CacheEvict(cacheNames = "favoritePerformance", allEntries = true)
+      @CacheEvict(cacheNames = "performanceRank", allEntries = true)
   })
   @Transactional
   public void delete(UUID id) {

--- a/src/main/java/com/sprint/mission/findex/domain/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/indexinfo/service/IndexInfoService.java
@@ -19,6 +19,8 @@ import com.sprint.mission.findex.global.exception.ApiException;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +35,7 @@ public class IndexInfoService {
 
   private final IndexInfoMapper mapper;
 
+  @CacheEvict(cacheNames = "indexInfoSummaries", allEntries = true)
   @Transactional
   public IndexInfoResponse createByUser(IndexInfoCreateRequest req) {
     IndexInfo indexInfo = create(req, SourceType.USER);
@@ -44,6 +47,7 @@ public class IndexInfoService {
     return create(req, SourceType.OPEN_API);
   }
 
+  @CacheEvict(cacheNames = "indexInfoSummaries", allEntries = true)
   @Transactional
   public IndexInfoResponse updateByUser(UUID id, IndexInfoUpdateRequest req) {
     IndexInfo indexInfo = findByIdOrThrow(id);
@@ -67,6 +71,7 @@ public class IndexInfoService {
     return indexInfo;
   }
 
+  @CacheEvict(cacheNames = "indexInfoSummaries", allEntries = true)
   @Transactional
   public void delete(UUID id) {
     IndexInfo indexInfo = findByIdOrThrow(id);
@@ -77,6 +82,7 @@ public class IndexInfoService {
     return indexInfoRepository.findIndexInfos(condition);
   }
 
+  @Cacheable("indexInfoSummaries")
   public List<IndexInfoSummaryResponse> getSummaries() {
     return this.indexInfoRepository.findIndexInfoSummaries();
   }

--- a/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/domain/syncjob/service/SyncJobService.java
@@ -31,6 +31,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +57,7 @@ public class SyncJobService {
   private int fallbackLimitDays;
 
   private final IndexDataSyncProcessor indexDataSyncProcessor;
+  private final CacheManager cacheManager;
 
   public List<SyncJobResponse> syncIndexInfos(LocalDate targetDate, String workerIp) {
     List<IndexDataApiResponse> responses = List.of();
@@ -136,8 +139,10 @@ public class SyncJobService {
         }
       }
     }
+    evictIndexInfoCaches();
     return results;
   }
+
   public List<SyncJobResponse> syncIndexData(List<String> indexInfoIds, LocalDate baseDateFrom, LocalDate baseDateTo, String workerIp) {
 
     if (baseDateFrom.isAfter(baseDateTo)) {
@@ -226,6 +231,7 @@ public class SyncJobService {
         }
       }
     }
+    evictIndexDataCaches();
     return results;
   }
 
@@ -234,6 +240,26 @@ public class SyncJobService {
     return syncJobRepository.searchSyncJobPage(
         condition, condition.cursor(), condition.idAfter(),
         condition.sortField(), condition.sortDirection(), condition.size());
+  }
+
+  private void evictIndexInfoCaches() {
+    List.of("indexInfoSummaries", "indexChart", "performanceRank", "favoritePerformance")
+        .forEach(name -> {
+          Cache cache = cacheManager.getCache(name);
+          if (cache != null) {
+            cache.clear();
+          }
+        });
+  }
+
+  private void evictIndexDataCaches() {
+    List.of("indexChart", "performanceRank", "favoritePerformance")
+        .forEach(name -> {
+          Cache cache = cacheManager.getCache(name);
+          if (cache != null) {
+            cache.clear();
+          }
+        });
   }
 
   private void trySaveIndexData(IndexDataApiResponse response, IndexInfo indexInfo, LocalDate targetDate, String workerIp) {

--- a/src/main/java/com/sprint/mission/findex/global/config/CacheConfig.java
+++ b/src/main/java/com/sprint/mission/findex/global/config/CacheConfig.java
@@ -1,0 +1,30 @@
+package com.sprint.mission.findex.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties(CacheConfig.CaffeineProperties.class)
+@RequiredArgsConstructor
+@Configuration
+public class CacheConfig {
+
+    @ConfigurationProperties(prefix = "cache")
+    public record CaffeineProperties(Map<String, String> specs) {}
+
+    private final CaffeineProperties caffeineProperties;
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+        caffeineProperties.specs().forEach((name, spec) ->
+            manager.registerCustomCache(name, Caffeine.from(spec).build()));
+        return manager;
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #155

## PR 유형

- [x] feat: 새로운 기능

## 작업 내용

- `CacheConfig` + 내부 `CaffeineProperties` record로 캐시별 개별 spec 설정 (maximumSize, expireAfterWrite=24h)
- 대시보드 4개 API에 `@Cacheable` 적용 (indexInfoSummaries, indexChart, favoritePerformance, performanceRank)
- IndexInfo CRUD 시 indexInfoSummaries·favoritePerformance evict 적용
- IndexData CRUD 시 indexChart·performanceRank·favoritePerformance evict 적용
- 배치 자동 연동(SyncScheduler) 완료 시 indexChart·performanceRank·favoritePerformance evict
- 수동 연동(SyncJobService) syncIndexInfos 완료 시 전체 캐시 evict, syncIndexData 완료 시 indexInfoSummaries 제외 evict

## 테스트 내용

- [x] 로컬 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- `SyncJobService` evict 분리: syncIndexInfos(전체) vs syncIndexData(indexInfoSummaries 제외) 구분이 적절한지
- `CacheConfig` 내부 record(`CaffeineProperties`) 구조 적합성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캐싱 시스템 도입으로 대시보드 성능 최적화

* **개선 사항**
  * 차트 및 성능 데이터 캐싱으로 조회 속도 향상
  * 인덱스 정보 업데이트 시 캐시 자동 갱신으로 데이터 신선도 보장
  * 동기화 작업 완료 시 관련 캐시 자동 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->