### PR TITLE
fix: Railway 배포 환경 응답 지연 해소

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'


### PR DESCRIPTION
## 관련 이슈

- Closes #156

## PR 유형

- [x] fix: 버그 수정

## 작업 내용

- `spring-boot-starter-actuator` 의존성 추가
- `application-prod.yml`에 `/actuator/health`만 노출하도록 설정 (노출 엔드포인트: health 단일)

## 테스트 내용

- [ ] 로컬 테스트 완료

## 체크리스트

- [ ] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- `application-prod.yml`은 gitignore로 커밋 불가 → 팀 노션 페이지에 설정 내용 기재해뒀으니 확인 후 각자 로컬/배포 환경에 반영 필요