### PR TITLE
fix: GlobalExceptionHandler 미처리 예외 분기 추가

### DIFF
--- a/src/main/java/com/sprint/mission/findex/global/exception/ApiException.java
+++ b/src/main/java/com/sprint/mission/findex/global/exception/ApiException.java
@@ -27,8 +27,11 @@ public class ApiException extends RuntimeException {
     INVALID_SORT_FIELD("AUTO_SYNC_002", "유효하지 않은 정렬 필드입니다.", HttpStatus.BAD_REQUEST),
 
     // Common
-    COMMON_INVALID_REQUEST("COMMON_001", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
-    COMMON_UNEXPECTED_ERROR("COMMON_002", "예기치 않은 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    COMMON_UNEXPECTED_ERROR("COMMON_001", "예기치 않은 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    COMMON_NOT_FOUND("COMMON_002", "요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COMMON_METHOD_NOT_ALLOWED("COMMON_003", "지원하지 않는 HTTP 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
+    COMMON_MESSAGE_NOT_READABLE("COMMON_004", "잘못된 요청 형식입니다.", HttpStatus.BAD_REQUEST),
+    COMMON_INVALID_REQUEST("COMMON_005", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST);
 
 
 

--- a/src/main/java/com/sprint/mission/findex/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprint/mission/findex/global/exception/GlobalExceptionHandler.java
@@ -1,16 +1,23 @@
 package com.sprint.mission.findex.global.exception;
 
 import static com.sprint.mission.findex.global.exception.ApiException.ERROR.COMMON_INVALID_REQUEST;
+import static com.sprint.mission.findex.global.exception.ApiException.ERROR.COMMON_MESSAGE_NOT_READABLE;
+import static com.sprint.mission.findex.global.exception.ApiException.ERROR.COMMON_METHOD_NOT_ALLOWED;
+import static com.sprint.mission.findex.global.exception.ApiException.ERROR.COMMON_NOT_FOUND;
 import static com.sprint.mission.findex.global.exception.ApiException.ERROR.COMMON_UNEXPECTED_ERROR;
 
 import com.sprint.mission.findex.global.exception.ApiException.ERROR;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -37,7 +44,7 @@ public class GlobalExceptionHandler {
     String details = e.getBindingResult().getFieldErrors().stream()
         .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
         .collect(Collectors.joining(", "));
-    log.warn("[ApiException] {} status: {}, code: {}, message: {} | {}", error.name(),
+    log.warn("[ArgumentNotValid] {} status: {}, code: {}, message: {} | {}", error.name(),
         error.getHttpStatus().value(), error.getCode(), error.getMessage(), details);
     return ResponseEntity
         .status(error.getHttpStatus())
@@ -56,7 +63,7 @@ public class GlobalExceptionHandler {
         e.getName(),
         e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown"
     );
-    log.warn("[ApiException] {} status: {}, code: {}, message: {} | {}", error.name(),
+    log.warn("[ArgumentTypeMismatch] {} status: {}, code: {}, message: {} | {}", error.name(),
         error.getHttpStatus().value(), error.getCode(), error.getMessage(), details);
     return ResponseEntity
         .status(error.getHttpStatus())
@@ -65,6 +72,53 @@ public class GlobalExceptionHandler {
             error.getMessage(),
             error.getCode() + " | " + details
         ));
+  }
+
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<ErrorResponse> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+    ERROR error = COMMON_METHOD_NOT_ALLOWED;
+    log.warn("[MethodNotSupported] {} status: {}, code: {}, message: {}", error.name(),
+        error.getHttpStatus().value(), error.getCode(), e.getMessage());
+    return ResponseEntity
+        .status(error.getHttpStatus())
+        .body(ErrorResponse.of(
+            error.getHttpStatus().value(),
+            error.getMessage(),
+            error.getCode()
+        ));
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponse> handleMessageNotReadable(HttpMessageNotReadableException e) {
+    ERROR error = COMMON_MESSAGE_NOT_READABLE;
+    log.warn("[MessageNotReadable] {} status: {}, code: {}, message: {}", error.name(),
+        error.getHttpStatus().value(), error.getCode(), e.getMessage());
+    return ResponseEntity
+        .status(error.getHttpStatus())
+        .body(ErrorResponse.of(
+            error.getHttpStatus().value(),
+            error.getMessage(),
+            error.getCode()
+        ));
+  }
+
+  @ExceptionHandler(NoResourceFoundException.class)
+  public ResponseEntity<ErrorResponse> handleNoResourceFound(NoResourceFoundException e) {
+    ERROR error = COMMON_NOT_FOUND;
+    log.warn("[NoResourceFound] {} status: {}, code: {}, message: {}", error.name(),
+        error.getHttpStatus().value(), error.getCode(), e.getMessage());
+    return ResponseEntity
+        .status(error.getHttpStatus())
+        .body(ErrorResponse.of(
+            error.getHttpStatus().value(),
+            error.getMessage(),
+            error.getCode()
+        ));
+  }
+
+  @ExceptionHandler(ClientAbortException.class)
+  public void handleClientAbort(ClientAbortException e) {
+    log.warn("[ClientAbort] message: {}", e.getMessage());
   }
 
   @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 관련 이슈

- Closes #157

## PR 유형

- [x] fix: 버그 수정

## 작업 내용

- `HttpRequestMethodNotSupportedException` → 405 WARN 처리
- `HttpMessageNotReadableException` → 400 WARN 처리
- `NoResourceFoundException` → 404 WARN 처리
- `ClientAbortException` → 응답 없이 WARN 로그만 출력
- `ApiException.ERROR`에 `COMMON_003~005` 코드 추가

## 테스트 내용

- [ ] 로컬 테스트 완료

## 체크리스트

- [ ] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [x] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- `ClientAbortException` 핸들러 반환 타입 `void` — 응답 전송 불가 상황이므로 의도된 처리
- 기존 catch-all(`Exception`)은 진짜 미처리 예외만 도달하므로 풀 스택트레이스 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**버그 수정**
* 다양한 HTTP 오류 상황에 대한 예외 처리 개선
* 요청 경로 미발견, 메서드 미지원, 잘못된 요청 형식 등 구체적인 오류 시나리오에 대한 전담 처리 추가
* 오류 코드 및 상태 응답 재정리로 더욱 명확한 오류 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->